### PR TITLE
Various command line page fixes

### DIFF
--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -790,6 +790,9 @@ Alternatively, click or tap the button below to enter your Administrator account
   <data name="TimeoutText" xml:space="preserve">
     <value>Connection Timed Out</value>
   </data>
+  <data name="CommandTimeoutText" xml:space="preserve">
+    <value>Command Timed Out</value>
+  </data>
   <data name="UnsupportedAuthenticationProtocolText" xml:space="preserve">
     <value>Unsupported Authentication Protocol</value>
   </data>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
@@ -71,7 +71,7 @@
             </Popup>
             <ScrollViewer Name="StdOutputScroller"  Grid.Row="0" HorizontalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                 <RichTextBlock Name="StdOutputText" TextWrapping="NoWrap" FontFamily="Lucida Console" FontSize="12" IsTextSelectionEnabled="True" Margin="10 10" SizeChanged="StdOutputText_SizeChanged">
-                    <Paragraph>
+                    <Paragraph x:Name="MainParagraph">
                         <Run FontWeight="Bold" Text="{Binding [ExecAsDefaultAccount]}" />
                     </Paragraph>
                 </RichTextBlock>


### PR DESCRIPTION
Improve command line page with various fixes, including code cleanup, faster output performance, supporting a limit on the number of output lines per page to reduce chance of memory errors and enabling a timeout if a command is not responsive.