### PR TITLE
Command line page optimizations

### DIFF
--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/de-DE/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/de-DE/Resources.resw
@@ -694,7 +694,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; Befehlszeile eingeben</value>
+    <value>Befehlszeile eingeben</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -707,7 +707,7 @@
     <value>Ihr Gerät ist nicht zur Ausführung des Befehlszeilenprozessors berechtigt.
 Stellen Sie als "Administrator" (z. B. über PowerShell oder SSH) eine Verbindung mit Ihrem Gerät her, oder führen Sie im Windows Device Portal den folgenden Befehl aus, um die Ausführung zu aktivieren:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 Klicken oder tippen Sie alternativ auf die Schaltfläche unten, um das Kennwort Ihres Administratorkontos einzugeben und den Befehlszeilenprozessor zu aktivieren.
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/de-DE/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/de-DE/Resources.resw
@@ -715,8 +715,7 @@ Klicken oder tippen Sie alternativ auf die Schaltfläche unten, um das Kennwort 
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>Befehle werden unter DefaultAccount ausgeführt.
-    </value>
+    <value>Befehle werden unter DefaultAccount ausgeführt.</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>Schließen</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -790,10 +790,13 @@ Alternatively, click or tap the button below to enter your Administrator account
     <value>Connection Timed Out</value>
   </data>
   <data name="CommandTimeoutText" xml:space="preserve">
-    <value>Command Timed Out After {0} Seconds</value>
+    <value>Command timed out after {0} seconds of no output.</value>
   </data>
   <data name="CommandCancelled" xml:space="preserve">
-    <value>Command Cancelled</value>
+    <value>Command cancelled.</value>
+  </data>
+  <data name="CommandOutputTooLongeWarning" xml:space="preserve">
+    <value>Warning: Command output too long. Output trimmed.</value>
   </data>
   <data name="UnsupportedAuthenticationProtocolText" xml:space="preserve">
     <value>Unsupported Authentication Protocol</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -751,8 +751,7 @@ Alternatively, click or tap the button below to enter your Administrator account
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>Executing commands as DefaultAccount
-    </value>
+    <value>Executing commands as DefaultAccount</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>Close</value>
@@ -791,7 +790,10 @@ Alternatively, click or tap the button below to enter your Administrator account
     <value>Connection Timed Out</value>
   </data>
   <data name="CommandTimeoutText" xml:space="preserve">
-    <value>Command Timed Out</value>
+    <value>Command Timed Out After {0} Seconds</value>
+  </data>
+  <data name="CommandCancelled" xml:space="preserve">
+    <value>Command Cancelled</value>
   </data>
   <data name="UnsupportedAuthenticationProtocolText" xml:space="preserve">
     <value>Unsupported Authentication Protocol</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -790,6 +790,9 @@ Alternatively, click or tap the button below to enter your Administrator account
   <data name="TimeoutText" xml:space="preserve">
     <value>Connection Timed Out</value>
   </data>
+  <data name="CommandTimeoutText" xml:space="preserve">
+    <value>Command Timed Out</value>
+  </data>
   <data name="UnsupportedAuthenticationProtocolText" xml:space="preserve">
     <value>Unsupported Authentication Protocol</value>
   </data>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -730,20 +730,23 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; Enter command line</value>
+    <value>Enter command line</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
     <value>Clear</value>
   </data>
   <data name="CdNotSupported" xml:space="preserve">
-    <value>Change Directory not currently supported. Please use full paths in your commands.</value>
+    <value>Change directory not currently supported using "cd" command. Please update the folder name in the corresponding text box instead.</value>
+  </data>
+  <data name="WorkingDirectoryInvalid" xml:space="preserve">
+    <value>Invalid working directory : {0}</value>
   </data>
   <data name="CmdNotEnabled" xml:space="preserve">
     <value>Your device is not enabled to run the command line processor.
 To enable it, connect to your device as "Administrator" (e.g. using PowerShell or SSH) or use Windows Device Portal to run this command:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 Alternatively, click or tap the button below to enter your Administrator account's password and attempt to enable the command line processor.
 
@@ -791,6 +794,9 @@ Alternatively, click or tap the button below to enter your Administrator account
   </data>
   <data name="CommandTimeoutText" xml:space="preserve">
     <value>Command timed out after {0} seconds of no output.</value>
+  </data>
+  <data name="CommandLineError" xml:space="preserve">
+    <value>Error running command line: {0}</value>
   </data>
   <data name="CommandCancelled" xml:space="preserve">
     <value>Command cancelled.</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/es-ES/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/es-ES/Resources.resw
@@ -715,8 +715,7 @@ También puedes hacer clic o pulsar el botón que se muestra a continuación par
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>Ejecutar comandos como DefaultAccount
-    </value>
+    <value>Ejecutar comandos como DefaultAccount</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>Cerrar</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/es-ES/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/es-ES/Resources.resw
@@ -694,7 +694,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; Escribe una línea de comandos</value>
+    <value>Escribe una línea de comandos</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -707,7 +707,7 @@
     <value>El dispositivo no está habilitado para ejecutar el procesador de línea de comandos.
 Para habilitarlo, conecta el dispositivo como "administrador" (por ejemplo, usando PowerShell or SSH) o usa Windows Device Portal para ejecutar este comando
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 También puedes hacer clic o pulsar el botón que se muestra a continuación para escribir la contraseña de tu cuenta de administrador e intentar habilitar el procesador de línea de comandos.
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/fr-FR/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/fr-FR/Resources.resw
@@ -694,7 +694,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; Entrer la ligne de commande</value>
+    <value>Entrer la ligne de commande</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -707,7 +707,7 @@
     <value>Votre appareil n’est pas configuré de manière à pouvoir exécuter le processeur de ligne de commande.
 Pour qu'il puisse le faire, connectez-vous à votre appareil en tant qu'administrateur (p. ex. à l'aide de PowerShell or SSH) ou utilisez le Windows Device Portal pour exécuter la commande suivante :
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 Vous pouvez également cliquer ou appuyer sur le bouton ci-dessous pour entrer le mot de passe de votre compte administrateur et tenter d'activer le processeur de ligne de commande.
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/fr-FR/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/fr-FR/Resources.resw
@@ -715,8 +715,7 @@ Vous pouvez également cliquer ou appuyer sur le bouton ci-dessous pour entrer l
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>Exécution des commandes en tant que DefaultAccount
-    </value>
+    <value>Exécution des commandes en tant que DefaultAccount</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>Fermer</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/it-IT/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/it-IT/Resources.resw
@@ -702,8 +702,7 @@ In alternativa, tocca o fai clic sul pulsante di seguito per immettere la passwo
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>Esecuzione dei comandi come DefaultAccount
-    </value>
+    <value>Esecuzione dei comandi come DefaultAccount</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>Chiudi</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/it-IT/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/it-IT/Resources.resw
@@ -681,7 +681,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; Immetti la riga di comando</value>
+    <value>Immetti la riga di comando</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -694,7 +694,7 @@
     <value>Il tuo dispositivo non può eseguire il processore della riga di comando.
 Per abilitarlo, connettiti al dispositivo come "Amministratore" (ad esempio utilizzando PowerShell o SSH) oppure utilizza Windows Device Portal per eseguire questo comando:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 In alternativa, tocca o fai clic sul pulsante di seguito per immettere la password dell'account Amministratore e tentare di abilitare il processore della riga di comando.
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ja-JP/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ja-JP/Resources.resw
@@ -702,8 +702,7 @@
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>DefaultAccount としてコマンドを実行中
-    </value>
+    <value>DefaultAccount としてコマンドを実行中</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>閉じる</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ja-JP/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ja-JP/Resources.resw
@@ -681,7 +681,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; コマンド ラインを入力してください</value>
+    <value>コマンド ラインを入力してください</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -694,7 +694,7 @@
     <value>デバイスでコマンド ライン プロセッサの実行が有効になっていません。
 有効にするには、"管理者" としてデバイスに (たとえば PowerShell や SSH を使用して) 接続するか、Windows Device Portal を使用してこのコマンドを実行します:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 または、下にあるボタンをクリックするかタップして管理者アカウントのパスワードを入力し、コマンド ライン プロセッサを有効にしてください。
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ko-KR/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ko-KR/Resources.resw
@@ -702,8 +702,7 @@
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>DefaultAccount로 명령 실행 중
-    </value>
+    <value>DefaultAccount로 명령 실행 중</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>닫기</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ko-KR/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ko-KR/Resources.resw
@@ -681,7 +681,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; 명령줄 입력</value>
+    <value>명령줄 입력</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -694,7 +694,7 @@
     <value>장치에서 명령줄 프로세서를 실행할 수 없습니다.
 실행하도록 하려면 "관리자"로 장치에 연결하거나(PowerShell 또는 SSH 사용) Windows Device Portal을 사용해 이 명령을 실행하세요.
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 또는 아래 버튼을 클릭하거나 탭하여 관리자 계정의 비밀번호를 입력하고 명령줄 프로세서를 사용하도록 설정해 보세요.
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/pt-BR/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/pt-BR/Resources.resw
@@ -702,8 +702,7 @@ Você também pode clicar ou tocar no botão abaixo para inserir a senha da sua 
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>Executando comandos como DefaultAccount
-    </value>
+    <value>Executando comandos como DefaultAccount</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>Fechar</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/pt-BR/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/pt-BR/Resources.resw
@@ -681,7 +681,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; Insira a linha de comando</value>
+    <value>Insira a linha de comando</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -694,7 +694,7 @@
     <value>Seu dispositivo não está habilitado para executar o processador de linha de comando.
 Para habilitá-lo, conecte-se ao seu dispositivo como "Administrador" (por exemplo, usando o PowerShell ou SSH) ou use o Windows Device Portal para executar este comando:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 Você também pode clicar ou tocar no botão abaixo para inserir a senha da sua conta de Administrador e tentar habilitar o processador de linha de comando.
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ru-RU/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ru-RU/Resources.resw
@@ -715,8 +715,7 @@
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>Выполнение команд в роли DefaultAccount
-    </value>
+    <value>Выполнение команд в роли DefaultAccount</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>Закрыть</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ru-RU/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/ru-RU/Resources.resw
@@ -694,7 +694,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; введите командную строку</value>
+    <value>введите командную строку</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -707,7 +707,7 @@
     <value>На вашем устройстве невозможно запускать процессор командной строки.
 Чтобы это изменить, подключитесь к устройству как администратор (например, с помощью PowerShell или SSH) или войдите на Windows Device Portal и запустите эту команду:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 Также можно нажать расположенную ниже кнопку. Это позволит ввести пароль к учетной записи администратора и попытаться включить процессор командной строки.
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-CN/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-CN/Resources.resw
@@ -681,7 +681,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; 输入命令行</value>
+    <value>输入命令行</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -694,7 +694,7 @@
     <value>你的设备未启用，无法运行命令行处理器。
 要启用它，请以“管理员”身份(例如使用 PowerShell 或 SSH)连接到你的设备或使用 Windows Device Portal 运行以下命令:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 或者，单击或点击下面的按钮，输入你管理员帐户的密码并尝试启用命令行处理器。
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-CN/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-CN/Resources.resw
@@ -702,8 +702,7 @@
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>正在以 DefaultAccount 身份执行命令
-    </value>
+    <value>正在以 DefaultAccount 身份执行命令</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>关闭</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-TW/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-TW/Resources.resw
@@ -681,7 +681,7 @@
     <comment>Title for command line page</comment>
   </data>
   <data name="CommandLinePlaceholderText" xml:space="preserve">
-    <value>{0}&gt; 輸入命令列</value>
+    <value>輸入命令列</value>
     <comment>Placeholder for command line input text box</comment>
   </data>
   <data name="ClearPageText" xml:space="preserve">
@@ -694,7 +694,7 @@
     <value>您的裝置未啟用所以無法執行命令列處理器。
 若要啟用，請以「系統管理員」身分 (例如：使用 PowerShell 或 SSH) 連接您的裝置，或使用 Windows Device Portal 執行此命令:
 
-    reg ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\EmbeddedMode\ProcessLauncher" /f /v AllowedExecutableFilesList /t REG_MULTI_SZ /d "c:\windows\system32\cmd.exe\0"
+    {0}
 
 或者，按一下或輕觸下方的按鈕，輸入系統管理員帳戶的密碼，然後嘗試啟用命令列處理器。
 

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-TW/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/zh-TW/Resources.resw
@@ -702,8 +702,7 @@
     <comment>New lines need to be preserved</comment>
   </data>
   <data name="ExecAsDefaultAccount" xml:space="preserve">
-    <value>正在以 DefaultAccount 的身分執行命令
-    </value>
+    <value>正在以 DefaultAccount 的身分執行命令</value>
   </data>
   <data name="CloseText" xml:space="preserve">
     <value>關閉</value>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
@@ -71,7 +71,7 @@
             </Popup>
             <ScrollViewer Name="StdOutputScroller"  Grid.Row="0" HorizontalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                 <RichTextBlock Name="StdOutputText" TextWrapping="NoWrap" FontFamily="Lucida Console" FontSize="12" IsTextSelectionEnabled="True" Margin="10 10" SizeChanged="StdOutputText_SizeChanged">
-                    <Paragraph>
+                    <Paragraph x:Name="MainParagraph">
                         <Run FontWeight="Bold" Text="{Binding [ExecAsDefaultAccount]}" />
                     </Paragraph>
                 </RichTextBlock>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
@@ -79,16 +79,17 @@
             </ScrollViewer>
             <Grid Grid.Row="1" VerticalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-
-                <TextBox Grid.Column="0" x:Name="CommandLine" PlaceholderText="{Binding [CommandLinePlaceholderText]}" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" KeyUp="CommandLine_KeyUp" Height="24" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsSpellCheckEnabled="False" />
-                <Button Grid.Column="1" x:Name="RunButton" Content="{StaticResource IconRun}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="RunButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
-                <Button Grid.Column="2" x:Name="CancelButton" Content="{StaticResource IconCancel}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="CancelButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
-                <Button Grid.Column="3" x:Name="ClearButton" Content="{Binding [ClearPageText]}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontSize="16" Click="ClearButton_Click" Height="32" Width="Auto" VerticalAlignment="Center"/>
+                <TextBox Grid.Column="0" x:Name="WorkingDirectory" Text="C:\>" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" MinWidth="10" KeyUp="WorkingDirectory_KeyUp" LostFocus="WorkingDirectory_LostFocus" GotFocus="WorkingDirectory_GotFocus" Height="24" IsSpellCheckEnabled="False" />
+                <TextBox Grid.Column="1" x:Name="CommandLine" PlaceholderText="{Binding [CommandLinePlaceholderText]}" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" KeyUp="CommandLine_KeyUp" Height="24" IsSpellCheckEnabled="False" />
+                <Button Grid.Column="2" x:Name="RunButton" Content="{StaticResource IconRun}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="RunButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
+                <Button Grid.Column="3" x:Name="CancelButton" Content="{StaticResource IconCancel}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="CancelButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
+                <Button Grid.Column="4" x:Name="ClearButton" Content="{Binding [ClearPageText]}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontSize="16" Click="ClearButton_Click" Height="32" Width="Auto" VerticalAlignment="Center"/>
             </Grid>
 
         </Grid>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
@@ -70,9 +70,10 @@
                 </Border>
             </Popup>
             <ScrollViewer Name="StdOutputScroller"  Grid.Row="0" HorizontalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-                <RichTextBlock Name="StdOutputText" TextWrapping="NoWrap" FontFamily="Lucida Console" FontSize="12" IsTextSelectionEnabled="True" Margin="10 10" SizeChanged="StdOutputText_SizeChanged">
-                    <Paragraph x:Name="MainParagraph">
-                        <Run FontWeight="Bold" Text="{Binding [ExecAsDefaultAccount]}" />
+                <RichTextBlock Name="StdOutputText" TextWrapping="NoWrap" IsTextSelectionEnabled="True" Margin="10 10" SizeChanged="StdOutputText_SizeChanged">
+                    <Paragraph x:Name="MainParagraph" FontFamily="Lucida Console" FontSize="12" >
+                        <Run Text="{Binding [ExecAsDefaultAccount]}" Foreground="#FFF3FF00" FontWeight="Bold" />
+                        <Span><LineBreak /></Span>
                     </Paragraph>
                 </RichTextBlock>
             </ScrollViewer>
@@ -81,11 +82,13 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
                 <TextBox Grid.Column="0" x:Name="CommandLine" PlaceholderText="{Binding [CommandLinePlaceholderText]}" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" KeyUp="CommandLine_KeyUp" Height="24" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsSpellCheckEnabled="False" />
-                <Button Grid.Column="1" x:Name="RunButton" Content="{StaticResource IconRun}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="RunButton_Click" Height="24" Width="32" VerticalAlignment="Center"/>
-                <Button Grid.Column="2" x:Name="ClearButton" Content="{Binding [ClearPageText]}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontSize="14" Click="ClearButton_Click" Height="28" Width="Auto" VerticalAlignment="Center"/>
+                <Button Grid.Column="1" x:Name="RunButton" Content="{StaticResource IconRun}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="RunButton_Click" Height="28" Width="32" VerticalAlignment="Center"/>
+                <Button Grid.Column="2" x:Name="CancelButton" Content="{StaticResource IconCancel}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="CancelButton_Click" Height="28" Width="32" VerticalAlignment="Center"/>
+                <Button Grid.Column="3" x:Name="ClearButton" Content="{Binding [ClearPageText]}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontSize="16" Click="ClearButton_Click" Height="28" Width="Auto" VerticalAlignment="Center"/>
             </Grid>
 
         </Grid>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
@@ -86,9 +86,9 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBox Grid.Column="0" x:Name="CommandLine" PlaceholderText="{Binding [CommandLinePlaceholderText]}" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" KeyUp="CommandLine_KeyUp" Height="24" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsSpellCheckEnabled="False" />
-                <Button Grid.Column="1" x:Name="RunButton" Content="{StaticResource IconRun}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="RunButton_Click" Height="28" Width="32" VerticalAlignment="Center"/>
-                <Button Grid.Column="2" x:Name="CancelButton" Content="{StaticResource IconCancel}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="CancelButton_Click" Height="28" Width="32" VerticalAlignment="Center"/>
-                <Button Grid.Column="3" x:Name="ClearButton" Content="{Binding [ClearPageText]}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontSize="16" Click="ClearButton_Click" Height="28" Width="Auto" VerticalAlignment="Center"/>
+                <Button Grid.Column="1" x:Name="RunButton" Content="{StaticResource IconRun}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="RunButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
+                <Button Grid.Column="2" x:Name="CancelButton" Content="{StaticResource IconCancel}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="CancelButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
+                <Button Grid.Column="3" x:Name="ClearButton" Content="{Binding [ClearPageText]}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontSize="16" Click="ClearButton_Click" Height="32" Width="Auto" VerticalAlignment="Center"/>
             </Grid>
 
         </Grid>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml.cs
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml.cs
@@ -222,6 +222,15 @@ namespace IoTCoreDefaultApp
                         if (DateTime.Now.Subtract(lastOutputTime) > TimeOutAfterNoOutput)
                         {
                             // Timeout
+
+                            if (isPageOutput && numLinesInCurrentPage > 0 && !isCmdOutputWarningDisplayed)
+                            {
+                                await coreDispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                                {
+                                    AddLineToParagraph(isErrorRun, currentPage.ToString());
+                                });
+                            }
+
                             isProcessTimedOut = true;
                             processLauncherOperation.Cancel();
                         }


### PR DESCRIPTION
Improve command line performance and ensure it will display output as soon as the process starts - not when it's done, which would be useful with certain tools such as tracert or netstat that typically takes a long time between output bursts.
Reduce the chance of command line page crashing due to OOM errors.
Automatically cancel the command (which terminates the process) if a command takes too long before streaming any output.
Also, add a cancel button to cancel a command manually if it takes too long.
