### PR TITLE
Allow running commands as admin

### DIFF
--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Strings/en-US/Resources.resw
@@ -814,7 +814,7 @@ Alternatively, click or tap the button below to enter your Administrator account
     <value>Successfully enabled Command Line Processor (cmd.exe) on your device.</value>
   </data>
   <data name="CmdTextEnabledFailure" xml:space="preserve">
-    <value>Failed to enable Command Line Processor (cmd.exe) on your device. Status = {0}</value>
+    <value>Failed to enable Command Line Processor (cmd.exe) on your device: {0}</value>
   </data>
   <data name="DisconnectButtonContent" xml:space="preserve">
     <value>Disconnect</value>
@@ -900,7 +900,7 @@ Alternatively, click or tap the button below to enter your Administrator account
     <value>Inbound Pairing:</value>
     <comment>Label that shows inbound pairing status</comment>
   </data>
-    <data name="BluetoothOutboundLabel" xml:space="preserve">
+  <data name="BluetoothOutboundLabel" xml:space="preserve">
     <value>Outbound Pairing:</value>
     <comment>Label that shows outbound pairing status</comment>
   </data>
@@ -912,12 +912,22 @@ Alternatively, click or tap the button below to enter your Administrator account
     <value>No</value>
     <comment>Generic text for a No Label</comment>
   </data>
-    <data name="OKLabel" xml:space="preserve">
+  <data name="OKLabel" xml:space="preserve">
     <value>OK</value>
     <comment>Generic text for an OK Label</comment>
   </data>
   <data name="ChangeTimeZoneTitleText" xml:space="preserve">
     <value>Time zone</value>
     <comment>Time zone text</comment>
+  </data>
+  <data name="ContinueText" xml:space="preserve">
+    <value>Continue</value>
+    <comment>Continue</comment>
+  </data>
+  <data name="CmdTextAdminCommandFailure" xml:space="preserve">
+    <value>Failed to run command as Administrator: {0}</value>
+  </data>
+  <data name="CouldNotParseOutputFailure" xml:space="preserve">
+    <value>Could not parse command output</value>
   </data>
 </root>

--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Views/CommandLinePage.xaml
@@ -50,22 +50,14 @@
                 <RowDefinition Height="32"></RowDefinition>
                 <RowDefinition Height="2"></RowDefinition>
             </Grid.RowDefinitions>
-            <Popup x:Name="EnableCmdPopup" Grid.Row="0">
+            <Popup x:Name="GetCredentialsPopup" Grid.Row="0">
                 <Border BorderThickness="2" BorderBrush="LightGray" Background="Black">
-                    <StackPanel x:Name="EnableCmdStackPanel"  Height="172" Width="400">
+                    <StackPanel x:Name="CredentialsStackPanel" Height="172" Width="400">
                         <TextBlock Text="{Binding [UsernameText]}" FontSize="14"  Margin="10, 2, 10, 0" />
                         <TextBox x:Name="Username" FontSize="14" Text="administrator"  Margin="10, 2, 10, 4"/>
                         <TextBlock Text="{Binding [PasswordText]}" FontSize="14"  Margin="10, 2, 10, 0"/>
-                        <PasswordBox x:Name="Password" FontSize="14"  Margin="10, 2, 10, 10"/>
-                        <Button x:Name="EnableCmdLineButton" Content="{Binding [EnableCmdText]}" HorizontalAlignment="Center" Click="EnableCmdLineButton_Click" />
-                    </StackPanel>
-                </Border>
-            </Popup>
-            <Popup  x:Name="CmdEnabledStatusPopup" Grid.Row="0">
-                <Border BorderThickness="2" BorderBrush="LightGray" Background="Black">
-                    <StackPanel x:Name="StatusStackPanel"  Height="120" Width="300">
-                        <TextBlock x:Name="CmdEnabledStatus" FontSize="14"  Margin="10, 10" TextWrapping="WrapWholeWords" />
-                        <Button x:Name="CloseStatusButton" Content="{Binding [CloseText]}" HorizontalAlignment="Center" Click="CloseStatusButton_Click" />
+                        <PasswordBox x:Name="Password" FontSize="14"  Margin="10, 2, 10, 10" KeyUp="Password_KeyUp"/>
+                        <Button x:Name="CredentialsPopupContinueButton" Content="{Binding [ContinueText]}" HorizontalAlignment="Center" Click="CredentialsPopupContinueButton_Click" />
                     </StackPanel>
                 </Border>
             </Popup>
@@ -86,7 +78,7 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <TextBox Grid.Column="0" x:Name="WorkingDirectory" Text="C:\>" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" MinWidth="10" KeyUp="WorkingDirectory_KeyUp" LostFocus="WorkingDirectory_LostFocus" GotFocus="WorkingDirectory_GotFocus" Height="24" IsSpellCheckEnabled="False" />
-                <TextBox Grid.Column="1" x:Name="CommandLine" PlaceholderText="{Binding [CommandLinePlaceholderText]}" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" KeyUp="CommandLine_KeyUp" Height="24" IsSpellCheckEnabled="False" />
+                <TextBox Grid.Column="1" x:Name="CommandLine" PlaceholderText="{Binding [CommandLinePlaceholderText]}" Background="Transparent" BorderThickness="2" BorderBrush="Transparent" FontFamily="Lucida Console" FontSize="14" Padding="6 6" KeyUp="CommandLine_KeyUp" Height="24" IsSpellCheckEnabled="False" AllowFocusWhenDisabled="True" />
                 <Button Grid.Column="2" x:Name="RunButton" Content="{StaticResource IconRun}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="RunButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
                 <Button Grid.Column="3" x:Name="CancelButton" Content="{StaticResource IconCancel}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontFamily="{StaticResource IconFontFamily}" FontSize="16" Click="CancelButton_Click" Height="32" Width="32" VerticalAlignment="Center"/>
                 <Button Grid.Column="4" x:Name="ClearButton" Content="{Binding [ClearPageText]}" Background="Transparent" BorderThickness="0" BorderBrush="Transparent" FontSize="16" Click="ClearButton_Click" Height="32" Width="Auto" VerticalAlignment="Center"/>


### PR DESCRIPTION
Uses WDP REST APIs to provide the ability to run a command using Administrator account. To run a command as admininstrator, the command should be preceded by "runasadmin ". The UI will then prompt for the administrator password. Those credentials will be used to authenticate the HTTP POST with WDP.
Prerequisites: WDP must be available and running on the default port and protocol. Additionally, loopback must be allowed for the app. "CheckNetIsolation.exe LoopbackExempt" can be used to enable a loopback exemption.
Also, this commit contains a few other UI fixes and code cleanup.