### PR TITLE
Bug 15845111: Device enumerated more than once

### DIFF
--- a/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Presenters/ConnectedDevicePresenter.cs
+++ b/Samples/IoTCoreDefaultApp/CS/IoTCoreDefaultApp/Presenters/ConnectedDevicePresenter.cs
@@ -16,7 +16,7 @@ namespace IoTCoreDefaultApp
     public class ConnectedDevicePresenter
     {
         private CoreDispatcher dispatcher;
-        const string usbDevicesSelector = "(System.Devices.InterfaceClassGuid:=\"{" + Constants.GUID_DEVINTERFACE_USB_DEVICE + "}\")";
+        const string usbDevicesSelector = "(System.Devices.InterfaceClassGuid:=\"{" + Constants.GUID_DEVINTERFACE_USB_DEVICE + "}\" AND System.Devices.InterfaceEnabled:=System.StructuredQueryType.Boolean#True)";
 
         public ConnectedDevicePresenter(CoreDispatcher dispatcher)
         {


### PR DESCRIPTION
This change fixes an enumeration issue where the device watcher's AQS string was including all device interfaces that were ever present on a usb port.  The new change only enumerates a device if it's actually present.