### PR TITLE
Update the "Headed mode" link

### DIFF
--- a/Samples/VideoCaptureSample/CS/README.md
+++ b/Samples/VideoCaptureSample/CS/README.md
@@ -2,7 +2,7 @@
 
 Initialize a video capture device, record video to a file, preview video feed, and playback recorded video.
 
-This is a headed sample.  To better understand what headed mode is and how to configure your device to be headed, follow the instructions [here](/Docs/HeadlessMode).
+This is a headed sample.  To better understand what headed mode is and how to configure your device to be headed, follow the instructions [here](https://docs.microsoft.com/en-us/windows/iot-core/learn-about-hardware/headlessmode).
 
 ### Load the project in Visual Studio
 


### PR DESCRIPTION
The link was broken. Replace by the new link into the official documentation of Windows 10 IoT Core : https://docs.microsoft.com/en-us/windows/iot-core/learn-about-hardware/headlessmode