### PR TITLE
Move asynchelper to edgemodules common

### DIFF
--- a/Samples/EdgeModules/Common/CS/Common/AsyncHelper.cs
+++ b/Samples/EdgeModules/Common/CS/Common/AsyncHelper.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace EdgeModuleSamples.Common
 {
-    static class AsyncHelper
+    public static class AsyncHelper
     {
         // Work around this problem:
         // https://github.com/Microsoft/dotnet/issues/590

--- a/Samples/EdgeModules/Common/CS/Common/Common.csproj
+++ b/Samples/EdgeModules/Common/CS/Common/Common.csproj
@@ -2,6 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
+
+    <ItemGroup>
+    <Reference Include="Windows">
+      <HintPath>$(WINDOWS_WINMD)</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+    </Reference>
+  </ItemGroup>
 
 </Project>

--- a/Samples/EdgeModules/SqueezeNetObjectDetection/cs/AsyncHelper.cs
+++ b/Samples/EdgeModules/SqueezeNetObjectDetection/cs/AsyncHelper.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using Windows.Foundation;
 using System.Threading;
 
-namespace Helpers
+namespace EdgeModuleSamples.Common
 {
     static class AsyncHelper
     {

--- a/Samples/EdgeModules/SqueezeNetObjectDetection/cs/FrameSource.cs
+++ b/Samples/EdgeModules/SqueezeNetObjectDetection/cs/FrameSource.cs
@@ -8,7 +8,7 @@ using Windows.Media.Capture.Frames;
 using Windows.Media.MediaProperties;
 
 using EdgeModuleSamples.Common;
-using static Helpers.AsyncHelper;
+using static EdgeModuleSamples.Common.AsyncHelper;
 
 //
 // This sample directly implements the following:

--- a/Samples/EdgeModules/SqueezeNetObjectDetection/cs/Program.cs
+++ b/Samples/EdgeModules/SqueezeNetObjectDetection/cs/Program.cs
@@ -16,8 +16,8 @@ using Windows.Foundation;
 using Windows.Media;
 
 using EdgeModuleSamples.Common;
+using static EdgeModuleSamples.Common.AsyncHelper;
 using static Helpers.BlockTimerHelper;
-using static Helpers.AsyncHelper;
 
 namespace SampleModule
 {

--- a/Samples/EdgeModules/SqueezeNetObjectDetection/cs/Scoring.cs
+++ b/Samples/EdgeModules/SqueezeNetObjectDetection/cs/Scoring.cs
@@ -5,7 +5,8 @@ using Windows.Media;
 using Windows.Storage;
 using Windows.Storage.Streams;
 using Windows.AI.MachineLearning;
-using static Helpers.AsyncHelper;
+
+using static EdgeModuleSamples.Common.AsyncHelper;
 
 namespace SampleModule
 {


### PR DESCRIPTION
@seanmcd-msft please review. (Can't add him to reviewers for some reason)

This move will force us to reconcile our handling of WinMD files. Squeeenet sample follows the Windows-Machine-Learning samples repo convention of pulling in the entire winmd file from $WINDOWS_WINMD. The Custom Vision sample pulls individual contracts. Either way, we need to use an environment var for the location, because there are multiple SDK versions a developer could have on his/her machine.

Also moved common to C#7.3 for 'default' literal. Hopefully this isn't controversial!