### PR TITLE
USB Serial Access module for Azure IoT Edge

### DIFF
--- a/Samples/EdgeModules/README.md
+++ b/Samples/EdgeModules/README.md
@@ -15,6 +15,7 @@ This directory contains sample modules demonstrating various features of Azure I
 <table>
  <tr>
   <td><a href="./ConsoleDotNetCoreWinML">ConsoleDotNetCoreWinML</a></td>
+  <td><a href="./SerialIOPorts">SerialIOPorts</a></td>
   <td><a href="./SerialWin32">SerialWin32</a></td>
   <td><a href="./SqueezeNetObjectDetection">SqueezeNetObjectDetection</a></td>
  </tr>

--- a/Samples/EdgeModules/SerialIOPorts/CS/AppOptions.cs
+++ b/Samples/EdgeModules/SerialIOPorts/CS/AppOptions.cs
@@ -1,0 +1,46 @@
+﻿using Mono.Options;
+using System;
+using System.Collections.Generic;
+
+namespace SampleModule
+{
+    public class AppOptions: OptionSet
+    {
+        public bool Help { get; private set; }
+        public bool ShowList { get; private set; }
+        public bool ShowConfig { get; private set; }
+        public bool Receive { get; private set; }
+        public bool Transmit { get; private set; }
+        public string DeviceId { get; private set; }
+        public bool UseEdge { get; private set; }
+        public bool Exit { get; private set; } = false;
+
+        public AppOptions()
+        {
+            Add( "h|help", "show this message and exit", v => Help = v != null );
+            Add( "l|list", "list available devices and exit", v => ShowList = v != null);
+            Add( "d|device=", "the {ID} of device to connect", v => DeviceId = v);
+            Add( "r|receive", "receive and display packets", v => Receive = v != null);
+            Add( "t|transmit", "transmit packets (combine with -r for loopback)", v => Transmit = v != null);
+            Add( "c|config", "display device configuration", v => ShowConfig = v != null);
+            Add( "e|edge", "transmit through azure edge", v => UseEdge = v != null);
+        }
+
+        public new List<string> Parse(IEnumerable<string> args)
+        {
+            var result = base.Parse(args);
+
+            if (Help || !(Receive || Transmit || ShowList || ShowConfig))
+            {
+                Console.WriteLine($"{AppName} {AppVersion}");
+                WriteOptionDescriptions(Console.Out);
+                Exit = true;
+            }
+
+            return result;
+        }
+
+        static private string AppName => typeof(AppOptions).Assembly.GetName().Name;
+        static private string AppVersion => typeof(AppOptions).Assembly.GetName().Version.ToString();
+    }
+}

--- a/Samples/EdgeModules/SerialIOPorts/CS/Dockerfile
+++ b/Samples/EdgeModules/SerialIOPorts/CS/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/windows/nanoserver/insider:10.0.17763.55
+
+ARG EXE_DIR=bin/Debug/netcoreapp2.1/win-x64/publish
+
+WORKDIR /app
+
+COPY $EXE_DIR/ ./
+
+CMD [ "SerialIOPorts.exe", "-rte", "-dCOM4" ]

--- a/Samples/EdgeModules/SerialIOPorts/CS/Dockerfile
+++ b/Samples/EdgeModules/SerialIOPorts/CS/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-CMD [ "SerialIOPorts.exe", "-rte", "-dCOM4" ]
+CMD [ "SerialIOPorts.exe", "-rte", "-dCOM3" ]

--- a/Samples/EdgeModules/SerialIOPorts/CS/Dockerfile
+++ b/Samples/EdgeModules/SerialIOPorts/CS/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/windows/nanoserver/insider:10.0.17763.55
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
-ARG EXE_DIR=bin/Debug/netcoreapp2.1/win-x64/publish
+ARG EXE_DIR=.
 
 WORKDIR /app
 

--- a/Samples/EdgeModules/SerialIOPorts/CS/MessageBody.cs
+++ b/Samples/EdgeModules/SerialIOPorts/CS/MessageBody.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace SampleModule
+{
+    using System;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    ///Body:
+    ///{
+    ///  “machine”:{
+    ///    “temperature”:,
+    ///    “pressure”:
+    ///  },
+    ///  “ambient”:{
+    ///    “temperature”: , 
+    ///    “humidity”:
+    ///  }
+    ///  “timeCreated”:”UTC iso format”
+    ///}
+    ///Units and types:
+    ///Temperature: double, C
+    ///Humidity: int, %
+    ///Pressure: double, psi
+    /// </summary>
+    public class MessageBody
+    {
+        [JsonProperty(PropertyName = "machine")]
+        public Machine Machine { get; set; }
+
+        [JsonProperty(PropertyName = "ambient")]
+        public Ambient Ambient { get; set; }
+
+        [JsonProperty(PropertyName = "timeCreated")]
+        public DateTime TimeCreated { get; set; }
+
+        [JsonIgnore]
+        public int Number { get; set; }
+
+        [JsonIgnore]
+        public bool isValid {get;private set; } = false;
+
+
+        [JsonIgnore]
+        public string SerialEncode
+        {
+            get
+            {
+                return $"{Number:00000}/{Machine.SerialEncode}/{Ambient.SerialEncode}";
+            }
+            set
+            {
+                try
+                {
+                    var values = value.Split('/');
+                    Number = int.Parse(values[0]);
+                    Machine = new Machine();
+                    Machine.SerialEncode = values[1];
+                    Ambient = new Ambient();
+                    Ambient.SerialEncode = values[2];
+                    isValid = true;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+
+        // # of chars in a serial message
+        public const int SerialSize = 30;  
+    }
+
+    public class Machine
+    {
+        [JsonProperty(PropertyName = "temperature")]
+        public double Temperature { get; set; }
+
+        [JsonProperty(PropertyName = "pressure")]
+        public double Pressure { get; set; }
+
+        [JsonIgnore]
+        public string SerialEncode
+        {
+            get
+            {
+                return $"{Temperature:000.00},{Pressure:000.00}"; // 13 chars
+            }
+            set
+            {
+                try
+                {
+                    var values = value.Split(',');
+                    Temperature = double.Parse(values[0]);
+                    Pressure = double.Parse(values[1]);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+    }
+
+    public class Ambient
+    {
+        [JsonProperty(PropertyName = "temperature")]
+        public double Temperature { get; set; }
+
+        [JsonProperty(PropertyName = "humidity")]
+        public int Humidity { get; set; }
+
+        [JsonIgnore]
+        public string SerialEncode
+        {
+            get
+            {
+                return $"{Temperature:000.00},{Humidity:000}"; // 10 chars
+            }
+            set
+            {
+                try
+                {
+                    var values = value.Split(',');
+                    Temperature = double.Parse(values[0]);
+                    Humidity = int.Parse(values[1]);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+
+    }
+}

--- a/Samples/EdgeModules/SerialIOPorts/CS/MessageBody.cs
+++ b/Samples/EdgeModules/SerialIOPorts/CS/MessageBody.cs
@@ -4,6 +4,7 @@ namespace SampleModule
 {
     using System;
     using Newtonsoft.Json;
+    using EdgeModuleSamples.Common;
 
     /// <summary>
     ///Body:
@@ -62,7 +63,7 @@ namespace SampleModule
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+                    Log.WriteLineError($"In MessageBody SerialEncode set: {ex.GetType().Name} {ex.Message}");
                 }
             }
         }
@@ -96,7 +97,7 @@ namespace SampleModule
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+                    Log.WriteLineError($"In Machine SerialEncode set: {ex.GetType().Name} {ex.Message}");
                 }
             }
         }
@@ -127,7 +128,7 @@ namespace SampleModule
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
+                    Log.WriteLineError($"In Ambient SerialEncode set: {ex.GetType().Name} {ex.Message}");
                 }
             }
         }

--- a/Samples/EdgeModules/SerialIOPorts/CS/Program.cs
+++ b/Samples/EdgeModules/SerialIOPorts/CS/Program.cs
@@ -133,7 +133,7 @@ namespace SampleModule
             }
             catch (Exception ex)
             {
-                Log.WriteLineError($"{ex.GetType().Name} {ex.Message}");
+                Log.WriteLineError($"In Main: {ex.GetType().Name} {ex.Message}");
             }        
         }
 
@@ -201,9 +201,9 @@ namespace SampleModule
                             }
                         }
                     }
-                    catch (TimeoutException ex) 
+                    catch (Exception ex) 
                     { 
-                        Log.WriteLineError($"{ex.GetType().Name} {ex.Message}");
+                        Log.WriteLineError($"In ReaderTask loop: {ex.GetType().Name} {ex.Message}");
                     }
 
                     i++;
@@ -211,7 +211,7 @@ namespace SampleModule
             }
             catch (Exception ex)
             {
-                Log.WriteLineError($"{ex.GetType().Name} {ex.Message}");
+                Log.WriteLineError($"ReaderTask: {ex.GetType().Name} {ex.Message}");
             }
         }
 

--- a/Samples/EdgeModules/SerialIOPorts/CS/Program.cs
+++ b/Samples/EdgeModules/SerialIOPorts/CS/Program.cs
@@ -196,7 +196,7 @@ namespace SampleModule
                             {
                                 string dataBuffer = JsonConvert.SerializeObject(tempData); 
                                 var eventMessage = new Message(Encoding.UTF8.GetBytes(dataBuffer));
-                                Log.WriteLine($"SendEvent: [{dataBuffer}]");
+                                Log.WriteLineRaw($"SendEvent: [{dataBuffer}]");
                                 await ioTHubModuleClient.SendEventAsync("temperatureOutput", eventMessage);                        
                             }
                         }

--- a/Samples/EdgeModules/SerialIOPorts/CS/Program.cs
+++ b/Samples/EdgeModules/SerialIOPorts/CS/Program.cs
@@ -1,0 +1,234 @@
+namespace SampleModule
+{
+    using System;
+    using System.IO;
+    using System.IO.Ports;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Loader;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Linq;
+    using Microsoft.Azure.Devices.Client;
+    using Newtonsoft.Json;
+
+    class Program
+    {
+        static AppOptions Options;
+        static ModuleClient ioTHubModuleClient;
+        static readonly Random Rnd = new Random();
+
+        static void Main(string[] args)
+        {
+            try
+            {
+                //
+                // Parse options
+                //
+
+                Options = new AppOptions();
+
+                Options.Parse(args);
+
+                //
+                // Enumerate devices
+                //
+
+                var devicepaths = SerialPort.GetPortNames();
+                if (Options.ShowList || string.IsNullOrEmpty(Options.DeviceId))
+                {
+                    Console.WriteLine("Available devices:");
+
+                    foreach (var devicepath in devicepaths)
+                    {
+                        Console.WriteLine($"{devicepath}");
+                    }
+                    return;
+                }
+
+                //
+                // Open Device
+                //
+
+                var deviceid = devicepaths.Where(x => x.Contains(Options.DeviceId)).SingleOrDefault();
+                if (null == deviceid)
+                    throw new Exception($"Unable to find device containing {Options.DeviceId}");
+
+                Console.WriteLine($"{DateTime.Now.ToLocalTime()} Connecting to device {deviceid}...");
+
+                using (var device = new SerialPort())
+                {
+                    //
+                    // Configure Device
+                    //
+
+                    device.PortName = deviceid;
+                    device.BaudRate = 115200;
+                    device.Open();
+
+                    //
+                    // Dump device info
+                    //
+
+                    if (Options.ShowConfig)
+                    {
+                        Console.WriteLine("=====================================");
+
+                        Console.WriteLine($"Parity: {device.Parity}");
+                        Console.WriteLine($"Encoding: {device.Encoding}");
+                        Console.WriteLine($"BaudRate: {device.BaudRate}");
+                        Console.WriteLine($"DataBits: {device.DataBits}");
+                        Console.WriteLine($"StopBits: {device.StopBits}");
+                        Console.WriteLine($"Handshake: {device.Handshake}");
+
+                        Console.WriteLine("=====================================");
+                    }
+
+                    //
+                    // Init module client
+                    //
+
+                    if (Options.UseEdge)
+                    {
+                        Init().Wait();
+                    }
+
+                    //
+                    // Set up a background thread to read from the device
+                    //
+
+                    if (Options.Receive)
+                    {
+                        var background = Task.Run(() => ReaderTask(device));
+                    }
+
+                    //
+                    // Continuously write to serial device every second
+                    //
+
+                    if (Options.Transmit)
+                    {
+                        var background = Task.Run(() => TransmitTask(device));
+                    }
+
+                    // Wait until the app unloads or is cancelled
+                    if (Options.Receive || Options.Transmit)
+                    {
+                        var cts = new CancellationTokenSource();
+                        AssemblyLoadContext.Default.Unloading += (ctx) => cts.Cancel();
+                        Console.CancelKeyPress += (sender, cpe) => cts.Cancel();
+                        WhenCancelled(cts.Token).Wait();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"{DateTime.Now.ToLocalTime()} ERROR: {ex.GetType().Name} {ex.Message}");
+            }        
+        }
+
+        private static void TransmitTask(SerialPort device)
+        {
+            int i = 1;
+            while (true)
+            {
+                Thread.Sleep(1000);
+
+                // Come up with a new message
+
+                var tempData = new MessageBody
+                {
+                    Machine = new Machine
+                    {
+                        Temperature = Rnd.NextDouble() * 100.0,
+                        Pressure = Rnd.NextDouble() * 100.0,
+                    },
+                    Ambient = new Ambient
+                    {
+                        Temperature = Rnd.NextDouble() * 100.0,
+                        Humidity = Rnd.Next(24, 27)
+                    },
+                    Number = i
+                };
+
+                // Async write, using overlapped structure
+                var message = tempData.SerialEncode;
+                device.WriteLine(message);
+                Console.WriteLine($"{DateTime.Now.ToLocalTime()} Write {i} Completed. Wrote {message.Length} bytes: \"{message}\"");
+                i++;
+            }            
+        }
+
+        private static async void ReaderTask(SerialPort device)
+        {
+            try
+            {
+                //
+                // Continuously read from serial device
+                // and send those values to edge hub.
+                //
+
+                int i = 1;
+                while (true)
+                {
+                    try
+                    {
+                        string message = device.ReadLine();
+                        Console.WriteLine($"{DateTime.Now.ToLocalTime()} Read {i} Completed. Received {message.Length} bytes: \"{message}\"");
+
+                        // Translate it into a messagebody
+                        if (Options.UseEdge)
+                        {
+                            var tempData = new MessageBody();
+                            tempData.SerialEncode = message;
+                            tempData.TimeCreated = DateTime.Now;
+                            if (tempData.isValid)
+                            {
+                                string dataBuffer = JsonConvert.SerializeObject(tempData); 
+                                var eventMessage = new Message(Encoding.UTF8.GetBytes(dataBuffer));
+                                Console.WriteLine($"{DateTime.Now.ToLocalTime()} SendEvent: [{dataBuffer}]");
+                                await ioTHubModuleClient.SendEventAsync("temperatureOutput", eventMessage);                        
+                            }
+                        }
+                    }
+                    catch (TimeoutException ex) 
+                    { 
+                       Console.WriteLine($"{DateTime.Now.ToLocalTime()} ERROR: {ex.GetType().Name} {ex.Message}");                        
+                    }
+
+                    i++;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"{DateTime.Now.ToLocalTime()} ERROR: {ex.GetType().Name} {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Handles cleanup operations when app is cancelled or unloads
+        /// </summary>
+        public static Task WhenCancelled(CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).SetResult(true), tcs);
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Initializes the ModuleClient and sets up the callback to receive
+        /// messages containing temperature information
+        /// </summary>
+        static async Task Init()
+        {
+            AmqpTransportSettings amqpSetting = new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
+            ITransportSettings[] settings = { amqpSetting };
+
+            // Open a connection to the Edge runtime
+            ioTHubModuleClient = await ModuleClient.CreateFromEnvironmentAsync(settings);
+            await ioTHubModuleClient.OpenAsync();
+            Console.WriteLine($"{DateTime.Now.ToLocalTime()} IoT Hub module client initialized.");
+        }
+    }
+}

--- a/Samples/EdgeModules/SerialIOPorts/CS/README.md
+++ b/Samples/EdgeModules/SerialIOPorts/CS/README.md
@@ -23,16 +23,16 @@ Obtain an [FTDI Serial TTL-232 cable](https://www.adafruit.com/product/70). Conn
 
 ## Build and Publish the Sample App
 
-Clone or download the sample repo. The first step from there is to publish it from a PowerShell command line, from the SerialWin32/CS directory.
+Clone or download the sample repo. The first step from there is to publish it from a PowerShell command line, from the SerialIOPorts/CS directory.
 
 ```
 PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> dotnet publish -r win-x64
 Microsoft (R) Build Engine version 15.8.166+gd4e8d81a88 for .NET Core
 Copyright (C) Microsoft Corporation. All rights reserved.
 
-  Restore completed in 53.44 ms for D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS\SerialWin32.csproj.
-  SerialWin32 -> D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS\bin\Debug\netcoreapp2.1\win-x64\SerialWin32.dll
-  SerialWin32 -> D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS\bin\Debug\netcoreapp2.1\win-x64\publish\
+  Restore completed in 53.44 ms for D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS\SerialIOPorts.csproj.
+  SerialIOPorts -> D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS\bin\Debug\netcoreapp2.1\win-x64\SerialIOPorts.dll
+  SerialIOPorts -> D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS\bin\Debug\netcoreapp2.1\win-x64\publish\
 ```
 
 ## Create a personal container repository
@@ -45,7 +45,7 @@ When following the sample, replace any "{ACR_*}" values with the correct values 
 Be sure to log into the container respository from your device.
 
 ```
-PS C:\data\modules\SerialWin32> docker login {ACR_NAME}.azurecr.io {ACR_USER} {ACR_PASSWORD}
+PS  D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker login {ACR_NAME}.azurecr.io {ACR_USER} {ACR_PASSWORD}
 ```
 
 ## Containerize the sample app
@@ -86,7 +86,7 @@ At this point, we'll want to run the container locally to ensure that it is able
 ```
 PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker run --device "class/86E0D1E0-8089-11D0-9CE4-08003E301F73" --isolation process $Container SerialIOPorts.exe
 
-SerialWin32 1.0.0.0
+SerialIOPorts 1.0.0.0
   -h, --help                 show this message and exit
   -l, --list                 list available devices and exit
   -d, --device=ID            the ID of device to connect
@@ -105,7 +105,7 @@ Notice that we are overriding the entry point from the command line.
 Now let's pick a device and ensure we can open it:
 
 ```
-PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker run --device "class/86E0D1E0-8089-11D0-9CE4-08003E301F73" --isolation process $Container SerialWin32.exe -c -dCOM3
+PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker run --device "class/86E0D1E0-8089-11D0-9CE4-08003E301F73" --isolation process $Container SerialIOPorts.exe -c -dCOM3
 
 11/20/2018 8:11:29 AM Connecting to device COM3}...
 =====================================

--- a/Samples/EdgeModules/SerialIOPorts/CS/README.md
+++ b/Samples/EdgeModules/SerialIOPorts/CS/README.md
@@ -208,32 +208,23 @@ From a command prompt on the device, you can also check the logs for the module 
 First, find the module container:
 
 ```
-PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker ps
-
-CONTAINER ID        IMAGE                                                                           COMMAND                  CREATED              STATUS              PORTS                                                                  NAMES
-b4107d30a29d        {ACR_NAME}.azurecr.io/serialioports:1.0.2-x64                                   "SerialIOPorts.exe -rt…"   About a minute ago   Up About a minute                                                                     serialioports
-56170371f8f5        edgeshared.azurecr.io/microsoft/azureiotedge-hub:1809_insider-windows-arm32     "dotnet Microsoft.Az…"   3 days ago           Up 6 minutes        0.0.0.0:443->443/tcp, 0.0.0.0:5671->5671/tcp, 0.0.0.0:8883->8883/tcp   edgeHub
-27c147e5c760        edgeshared.azurecr.io/microsoft/azureiotedge-agent:1809_insider-windows-arm32   "dotnet Microsoft.Az…"   3 days ago           Up 7 minutes                                                                               edgeAgent
+PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> iotedge list
+NAME             STATUS           DESCRIPTION      CONFIG
+serialioports    running          Up 5 minutes     {ACR_NAME}.azurecr.io/serialioports-com3:1.0.3-x64
+edgeHub          running          Up 33 minutes    mcr.microsoft.com/azureiotedge-hub:1.0.6
+edgeAgent        running          Up 33 minutes    mcr.microsoft.com/azureiotedge-agent:1.0.6
 ```
 
-Then, use the ID for the serialioports container to check the logs
+Then, check the logs
 
 ```
-PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker logs b4107d30a29d
-11/21/2018 4:48:33 PM Connecting to device COM3...
-11/21/2018 4:48:34 PM Write 1 Completed. Wrote 30 bytes: "00001/049.18,053.69/077.32,024"
-11/21/2018 4:48:34 PM Read 1 Completed. Received 30 bytes: "00001/049.18,053.69/077.32,024"
-11/21/2018 4:48:35 PM SendEvent: [{"machine":{"temperature":49.18,"pressure":53.69},"ambient":{"temperature":77.32,"humidity":24},"timeCreated":"2018-11-21T16:48:34.5113171-08:00"}]
-11/21/2018 4:48:35 PM Write 2 Completed. Wrote 30 bytes: "00002/061.68,097.79/053.30,026"
-11/21/2018 4:48:35 PM Read 2 Completed. Received 30 bytes: "00002/061.68,097.79/053.30,026"
-11/21/2018 4:48:35 PM SendEvent: [{"machine":{"temperature":61.68,"pressure":97.79},"ambient":{"temperature":53.3,"humidity":26},"timeCreated":"2018-11-21T16:48:35.5104208-08:00"}]
-11/21/2018 4:48:36 PM Write 3 Completed. Wrote 30 bytes: "00003/069.86,014.59/018.92,025"
-11/21/2018 4:48:36 PM Read 3 Completed. Received 30 bytes: "00003/069.86,014.59/018.92,025"
-11/21/2018 4:48:36 PM SendEvent: [{"machine":{"temperature":69.86,"pressure":14.59},"ambient":{"temperature":18.92,"humidity":25},"timeCreated":"2018-11-21T16:48:36.5173581-08:00"}]
-11/21/2018 4:48:37 PM Write 4 Completed. Wrote 30 bytes: "00004/030.22,061.69/088.52,024"
-11/21/2018 4:48:37 PM Read 4 Completed. Received 30 bytes: "00004/030.22,061.69/088.52,024"
-11/21/2018 4:48:37 PM SendEvent: [{"machine":{"temperature":30.22,"pressure":61.69},"ambient":{"temperature":88.52,"humidity":24},"timeCreated":"2018-11-21T16:48:37.5398929-08:00"}]
-11/21/2018 4:48:38 PM Write 5 Completed. Wrote 30 bytes: "00005/090.27,075.66/053.89,025"
-11/21/2018 4:48:38 PM Read 5 Completed. Received 30 bytes: "00005/090.27,075.66/053.89,025"
-11/21/2018 4:48:38 PM SendEvent: [{"machine":{"temperature":90.27,"pressure":75.66},"ambient":{"temperature":53.89,"humidity":25},"timeCreated":"2018-11-21T16:48:38.5312768-08:00"}]
+PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> iotedge logs serialioports
+2/22/2019 4:22:36 PM: Connecting to device COM3...
+2/22/2019 4:22:37 PM: IoT Hub module client initialized.
+2/22/2019 4:22:38 PM: Write 1 Completed. Wrote 30 bytes: "00001/006.28,078.44/065.91,025"
+2/22/2019 4:22:38 PM: Read 1 Completed. Received 30 bytes: "00001/006.28,078.44/065.91,025"
+2/22/2019 4:22:38 PM: SendEvent: [{"machine":{"temperature":6.28,"pressure":78.44},"ambient":{"temperature":65.91,"humidity":25},"timeCreated":"2019-02-22T16:22:38.7301052-08:00"}]
+2/22/2019 4:22:39 PM: Write 2 Completed. Wrote 30 bytes: "00002/004.93,004.32/008.44,026"
+2/22/2019 4:22:39 PM: Read 2 Completed. Received 30 bytes: "00002/004.93,004.32/008.44,026"
+2/22/2019 4:22:39 PM: SendEvent: [{"machine":{"temperature":4.93,"pressure":4.32},"ambient":{"temperature":8.44,"humidity":26},"timeCreated":"2019-02-22T16:22:39.7327389-08:00"}]
 ```

--- a/Samples/EdgeModules/SerialIOPorts/CS/README.md
+++ b/Samples/EdgeModules/SerialIOPorts/CS/README.md
@@ -1,0 +1,261 @@
+# USB Serial Access in an Azure IoT Edge module on Windows
+
+This document will walk you through creating a module for Azure IoT Edge on Windows 10 IoT Enterprise which accesses a USB Serial device.
+
+## STATUS: Substantially Completed
+
+This sample is pretty much ready to go. Just need to update to 1.0.5, test again, double check the formatting, and it can be published.
+
+## API Surface
+
+This sample uses standard .NET Core System.IO.Ports APIs to access the serial devices. 
+These APIs only work with serial devices which come named "COM{x}".
+Consequently, this approach is relevant on Windows 10 IoT Enterprise, but not Windows 10 IoT Core.
+
+WARNING: The current release (17763.55) of Windows 10 IoT Enterprise  does not contain the components needed to run the System.IO.Ports namespace from a container.
+We are currently working to update Windows 10 IoT Enterprise  to fix this problem. 
+After that update, for devices which follow the COMx naming pattern, you can use System.IO.Ports in your own solutions.
+In the meantime, the SerialWin32 sample shows the only available API surface for accessing serial ports from within Windows containers.
+
+## Install Azure IoT Edge
+
+These instructions work with the Private Preview build of Azure IoT Edge for Windows. If you do not have access, please contact Alex Newman <alnewman@microsoft.com>. Note that the private preview requires version 17763 of Windows.
+
+## Host Hardware
+
+These instructions will work on any PC running Windows 10, including Windows 10 IoT Enterprise.
+
+## Peripheral Hardware
+
+Obtain an [FTDI Serial TTL-232 cable](https://www.adafruit.com/product/70). Connect the RX and TX lines with a single wire. Plug this into your device.
+
+## Build and Publish the Sample App
+
+Currently the sample app is set up in a private repo. We will move the sample to a public location when win-arm docker and nanoserver containers are also public. For now, contact mailto:jcoliz@xbox.com for access to the private repo.
+
+* _Internal Users_: Clone https://mscodehub.visualstudio.com/jcoliz/_git/EdgeModules 
+* _EEAP Partners_: Obtain the containers helper package from EEAP Collaborate. Copy the contents of EdgeModules folder onto your development PC.
+
+Then we can publish it from a PowerShell command line, from the SerialIOPorts/CS directory:
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> dotnet publish -r win-x64
+Microsoft (R) Build Engine version 15.8.166+gd4e8d81a88 for .NET Core
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+  Restore completed in 53.44 ms for D:\source\Repos\EdgeModules\SerialIOPorts\CS\SerialWin32.csproj.
+  SerialWin32 -> D:\source\Repos\EdgeModules\SerialIOPorts\CS\bin\Debug\netcoreapp2.1\win-x64\SerialWin32.dll
+  SerialWin32 -> D:\source\Repos\EdgeModules\SerialIOPorts\CS\bin\Debug\netcoreapp2.1\win-x64\publish\
+```
+
+## Create a personal container repository
+
+In order to deploy modules to your device, you will need access to a container respository.  
+Refer to the "Create a container registry" section in [Tutorial: Develop a C# IoT Edge module and deploy to your simulated device](https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-csharp-module)
+
+For this sample, I am using jcoliz.azurecr.io. 
+When following the sample, change this to your own repository of course.
+
+Be sure to log into the container respository from your device.
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> docker login jcoliz.azurecr.io jcoliz password
+```
+
+## Containerize the sample app
+
+The x64 containers can be build directly on a PC.
+For the remainder of this sample, we will use the environment variable $Container to refer to the address of our container.
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> $Container = "jcoliz.azurecr.io/serialioports:1.0.0-x64"
+
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> docker build . -f .\Dockerfile.windows-x64 -t $Container
+
+Sending build context to Docker daemon  81.89MB
+Step 1/5 : FROM mcr.microsoft.com/windows/nanoserver/insider:10.0.17763.55
+ ---> 91da8a971b53
+Step 2/5 : ARG EXE_DIR=bin/Debug/netcoreapp2.1/win-x64/publish
+ ---> Running in b537bd4962d6
+Removing intermediate container b537bd4962d6
+ ---> 6d6281589c30
+Step 3/5 : WORKDIR /app
+ ---> Running in b8f3943ab2e5
+Removing intermediate container b8f3943ab2e5
+ ---> 37f5488097e5
+Step 4/5 : COPY $EXE_DIR/ ./
+ ---> 49f265682955
+Step 5/5 : CMD [ "SerialIOPorts.exe", "-rte", "-dCOM3" ]
+ ---> Running in 1aedd449ffa4
+Removing intermediate container 1aedd449ffa4
+ ---> d6cbd51600e3
+Successfully built d6cbd51600e3
+Successfully tagged jcoliz.azurecr.io/serialioports:1.0.0-x64
+```
+
+## Test the sample app on the device
+
+At this point, we'll want to run the container locally to ensure that it is able to find and talk to our peripheral.
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> docker run --device "class/86E0D1E0-8089-11D0-9CE4-08003E301F73" --isolation process $Container SerialIOPorts.exe
+
+SerialWin32 1.0.0.0
+  -h, --help                 show this message and exit
+  -l, --list                 list available devices and exit
+  -d, --device=ID            the ID of device to connect
+  -r, --receive              receive and display packets
+  -t, --transmit             transmit packets (combine with -r for loopback)
+  -c, --config               display device configuration
+  -e, --edge                 transmit through azure edge
+Available devices:
+COM1
+COM3
+```
+
+This will show that the application is able to run through the container, and list the available devices. 
+Notice that we are overriding the entry point from the command line.
+
+WARNING: The current release (17763.55) of IoT Enterprise host OS does not contain the components needed to run the System.IO.Ports namespace in a container. The following step fails on the currently-released IoT
+Enterprise. We are working on releasing an update which enables this.
+
+Now let's pick a device and ensure we can open it:
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> docker run --device "class/86E0D1E0-8089-11D0-9CE4-08003E301F73" --isolation process $Container SerialWin32.exe -c -dCOM3
+
+11/20/2018 8:11:29 AM Connecting to device COM3}...
+=====================================
+BaudRate: 0x1C200
+Parity: 0x2
+StopBits: 0x0
+=====================================
+```
+
+## Push the container
+
+Now, we push the container into the repository which we built earlier. At this point, the container image is waiting for us to deploy.
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> docker push $Container
+
+The push refers to repository [jcoliz.azurecr.io/serialioports]
+bf4863b963b0: Preparing
+3ed1316f55e1: Preparing
+b4d9f6916bae: Preparing
+6d34deee1fa7: Preparing
+79c160bd8d82: Preparing
+79c160bd8d82: Skipped foreign layer
+b4d9f6916bae: Mounted from serial-module
+bf4863b963b0: Pushed
+6d34deee1fa7: Mounted from serial-module
+3ed1316f55e1: Pushed
+1.0.0-arm32: digest: sha256:9593c87a18198915118ecbdc7f5a308dbe34a15ef898bac3fb5d06730ae6d30a size: 1464
+```
+
+## Edit the deployment.json file
+
+In the repo, you will find a sample deployment.x64.json files.
+Search for "ACR_" and replace those values with the correct values for your container repository.
+The ACR_IMAGE must exactly match what you pushed, e.g. jcoliz.azurecr.io/serialioports:1.0.0-x64
+
+```
+    "$edgeAgent": {
+      "properties.desired": {
+        "runtime": {
+          "settings": {
+            "registryCredentials": {
+              "jiriatest": {
+                "username": "d3e6e3bc-2e38-4887-9073-2cf796462b15",
+                "password": "71181f94-a9b9-4b98-96a8-01c4ae8dff94",
+                "address": "edgeshared.azurecr.io"
+              },
+              "ACR_NAME": {
+                "username": "ACR_USER",
+                "password": "ACR_PASSWORD",
+                "address": "ACR_ADDRESS"
+              }
+            }
+          }
+        }
+...
+        "modules": {
+          "serial": {
+            "settings": {
+              "image": "ACR_IMAGE",
+              "createOptions": "{\"HostConfig\":{\"Devices\":[{\"CgroupPermissions\":\"\",\"PathInContainer\":\"\",\"PathOnHost\":\"class/86E0D1E0-8089-11D0-9CE4-08003E301F73\"}],\"Isolation\":\"Process\"}}"
+            }
+          }
+
+```
+
+## Deploy
+
+You can now deploy this deployment.json file to your device.
+For reference, please see [Deploy Azure IoT Edge modules from Visual Studio Code](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-deploy-modules-vscode)
+
+## Verify
+
+Using the Azure IoT Edge extension for Visual Studio Code, you can select your device and choose "Start Monitoring D2C Message". You should see this:
+
+```
+[IoTHubMonitor] [4:04:43 PM] Message received from [jcoliz-preview/serialioports]:
+{
+  "machine": {
+    "temperature": 56.32,
+    "pressure": 99.01
+  },
+  "ambient": {
+    "temperature": 95.51,
+    "humidity": 24
+  },
+  "timeCreated": "2018-11-19T16:04:43.0331117-08:00"
+}
+[IoTHubMonitor] [4:04:44 PM] Message received from [jcoliz-preview/serialioports]:
+{
+  "machine": {
+    "temperature": 14.47,
+    "pressure": 33.99
+  },
+  "ambient": {
+    "temperature": 83.95,
+    "humidity": 26
+  },
+  "timeCreated": "2018-11-19T16:04:44.0555983-08:00"
+}
+```
+
+From a command prompt on the device, you can also check the logs for the module itself.
+
+First, find the module container:
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> docker ps
+
+CONTAINER ID        IMAGE                                                                           COMMAND                  CREATED              STATUS              PORTS                                                                  NAMES
+b4107d30a29d        jcoliz.azurecr.io/serialioports:1.0.2-x64                                       "SerialIOPorts.exe -rt…"   About a minute ago   Up About a minute                                                                          serialioports
+56170371f8f5        edgeshared.azurecr.io/microsoft/azureiotedge-hub:1809_insider-windows-arm32     "dotnet Microsoft.Az…"   3 days ago           Up 6 minutes        0.0.0.0:443->443/tcp, 0.0.0.0:5671->5671/tcp, 0.0.0.0:8883->8883/tcp   edgeHub
+27c147e5c760        edgeshared.azurecr.io/microsoft/azureiotedge-agent:1809_insider-windows-arm32   "dotnet Microsoft.Az…"   3 days ago           Up 7 minutes                                                                               edgeAgent
+```
+
+Then, use the ID for the serialioports container to check the logs
+
+```
+PS D:\source\Repos\EdgeModules\SerialIOPorts\CS> docker logs b4107d30a29d
+11/21/2018 4:48:33 PM Connecting to device COM3...
+11/21/2018 4:48:34 PM Write 1 Completed. Wrote 30 bytes: "00001/049.18,053.69/077.32,024"
+11/21/2018 4:48:34 PM Read 1 Completed. Received 30 bytes: "00001/049.18,053.69/077.32,024"
+11/21/2018 4:48:35 PM SendEvent: [{"machine":{"temperature":49.18,"pressure":53.69},"ambient":{"temperature":77.32,"humidity":24},"timeCreated":"2018-11-21T16:48:34.5113171-08:00"}]
+11/21/2018 4:48:35 PM Write 2 Completed. Wrote 30 bytes: "00002/061.68,097.79/053.30,026"
+11/21/2018 4:48:35 PM Read 2 Completed. Received 30 bytes: "00002/061.68,097.79/053.30,026"
+11/21/2018 4:48:35 PM SendEvent: [{"machine":{"temperature":61.68,"pressure":97.79},"ambient":{"temperature":53.3,"humidity":26},"timeCreated":"2018-11-21T16:48:35.5104208-08:00"}]
+11/21/2018 4:48:36 PM Write 3 Completed. Wrote 30 bytes: "00003/069.86,014.59/018.92,025"
+11/21/2018 4:48:36 PM Read 3 Completed. Received 30 bytes: "00003/069.86,014.59/018.92,025"
+11/21/2018 4:48:36 PM SendEvent: [{"machine":{"temperature":69.86,"pressure":14.59},"ambient":{"temperature":18.92,"humidity":25},"timeCreated":"2018-11-21T16:48:36.5173581-08:00"}]
+11/21/2018 4:48:37 PM Write 4 Completed. Wrote 30 bytes: "00004/030.22,061.69/088.52,024"
+11/21/2018 4:48:37 PM Read 4 Completed. Received 30 bytes: "00004/030.22,061.69/088.52,024"
+11/21/2018 4:48:37 PM SendEvent: [{"machine":{"temperature":30.22,"pressure":61.69},"ambient":{"temperature":88.52,"humidity":24},"timeCreated":"2018-11-21T16:48:37.5398929-08:00"}]
+11/21/2018 4:48:38 PM Write 5 Completed. Wrote 30 bytes: "00005/090.27,075.66/053.89,025"
+11/21/2018 4:48:38 PM Read 5 Completed. Received 30 bytes: "00005/090.27,075.66/053.89,025"
+11/21/2018 4:48:38 PM SendEvent: [{"machine":{"temperature":90.27,"pressure":75.66},"ambient":{"temperature":53.89,"humidity":25},"timeCreated":"2018-11-21T16:48:38.5312768-08:00"}]
+```

--- a/Samples/EdgeModules/SerialIOPorts/CS/README.md
+++ b/Samples/EdgeModules/SerialIOPorts/CS/README.md
@@ -8,18 +8,14 @@ This sample uses standard .NET Core System.IO.Ports APIs to access the serial de
 These APIs only work with serial devices which come named "COM{x}".
 Consequently, this approach is relevant on Windows 10 IoT Enterprise, but not Windows 10 IoT Core.
 
-WARNING: The current release (17763.55) of Windows 10 IoT Enterprise  does not contain the components needed to run the System.IO.Ports namespace from a container.
-We are currently working to update Windows 10 IoT Enterprise  to fix this problem. 
-After that update, for devices which follow the COMx naming pattern, you can use System.IO.Ports in your own solutions.
-In the meantime, the SerialWin32 sample shows the only available API surface for accessing serial ports from within Windows containers.
-
 ## Install Azure IoT Edge
 
 These instructions work with the 1.0.5 release of [Azure IoT Edge for Windows](https://docs.microsoft.com/en-us/azure/iot-edge/).
 
-## Host Hardware
+## Host Hardware & OS
 
-These instructions will work on any PC running Windows 10, including Windows 10 IoT Enterprise.
+These instructions will work on any PC running Windows 10, including Windows 10 IoT Enterprise. 
+The PC must be running build 17763 of Windows 10, and must be 17763.253 or higher.
 
 ## Peripheral Hardware
 

--- a/Samples/EdgeModules/SerialIOPorts/CS/README.md
+++ b/Samples/EdgeModules/SerialIOPorts/CS/README.md
@@ -10,7 +10,7 @@ Consequently, this approach is relevant on Windows 10 IoT Enterprise, but not Wi
 
 ## Install Azure IoT Edge
 
-These instructions work with the 1.0.5 release of [Azure IoT Edge for Windows](https://docs.microsoft.com/en-us/azure/iot-edge/).
+These instructions work with the 1.0.5 release of [Azure IoT Edge for Windows](https://docs.microsoft.com/en-us/azure/iot-edge/), or higher.
 
 ## Host Hardware & OS
 
@@ -45,7 +45,7 @@ When following the sample, replace any "{ACR_*}" values with the correct values 
 Be sure to log into the container respository from your device.
 
 ```
-PS  D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker login {ACR_NAME}.azurecr.io {ACR_USER} {ACR_PASSWORD}
+PS  D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker login {ACR_NAME}.azurecr.io -u {ACR_USER} -p {ACR_PASSWORD}
 ```
 
 ## Containerize the sample app
@@ -56,12 +56,12 @@ For the remainder of this sample, we will use the environment variable $Containe
 ```
 PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> $Container = "{ACR_NAME}.azurecr.io/serialioports:1.0.0-x64"
 
-PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker build . -f .\Dockerfile.windows-x64 -t $Container
+PS D:\Windows-iotcore-samples\Samples\EdgeModules\SerialIOPorts\CS> docker build bin\Debug\netcoreapp2.2\win-x64\publish\ -t $Container
 
 Sending build context to Docker daemon  81.89MB
-Step 1/5 : FROM mcr.microsoft.com/windows/nanoserver/insider:10.0.17763.55
+Step 1/5 : FROM mcr.microsoft.com/windows/nanoserver:1809
  ---> 91da8a971b53
-Step 2/5 : ARG EXE_DIR=bin/Debug/netcoreapp2.1/win-x64/publish
+Step 2/5 : ARG EXE_DIR=.
  ---> Running in b537bd4962d6
 Removing intermediate container b537bd4962d6
  ---> 6d6281589c30

--- a/Samples/EdgeModules/SerialIOPorts/CS/SerialIOPorts.csproj
+++ b/Samples/EdgeModules/SerialIOPorts/CS/SerialIOPorts.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Common\CS\Common\Common.csproj" />
-  </ItemGroup>
+    <Compile Include="..\..\Common\CS\Common\Log.cs" Link="Log.cs" />
+</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.0" />
@@ -26,4 +26,9 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.IO.Ports" Version="4.5.0" />    
   </ItemGroup>
+
+  <Target Name="CopyCustomContentOnPublish" AfterTargets="Publish">
+    <Copy SourceFiles="Dockerfile" DestinationFiles="$(PublishDir)\Dockerfile" />
+  </Target>
+
 </Project>

--- a/Samples/EdgeModules/SerialIOPorts/CS/SerialIOPorts.csproj
+++ b/Samples/EdgeModules/SerialIOPorts/CS/SerialIOPorts.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.1|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <TreatSpecificWarningsAsErrors />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Mono.Options.Core" Version="1.0.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
+    <PackageReference Include="System.IO.Ports" Version="4.5.0" />    
+  </ItemGroup>
+</Project>

--- a/Samples/EdgeModules/SerialIOPorts/CS/SerialIOPorts.csproj
+++ b/Samples/EdgeModules/SerialIOPorts/CS/SerialIOPorts.csproj
@@ -1,13 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.1|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\CS\Common\Common.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.0" />

--- a/Samples/EdgeModules/SerialIOPorts/CS/deployment.x64.json
+++ b/Samples/EdgeModules/SerialIOPorts/CS/deployment.x64.json
@@ -53,7 +53,7 @@
       "properties.desired": {
         "schemaVersion": "1.0",
         "routes": {
-          "sensorToSampleModule": "FROM /messages/modules/serialwin32/outputs/temperatureOutput INTO $upstream"
+          "sensorToSampleModule": "FROM /messages/modules/serialioports/outputs/temperatureOutput INTO $upstream"
         },
         "storeAndForwardConfiguration": {
           "timeToLiveSecs": 7200

--- a/Samples/EdgeModules/SerialIOPorts/CS/deployment.x64.json
+++ b/Samples/EdgeModules/SerialIOPorts/CS/deployment.x64.json
@@ -1,0 +1,69 @@
+{
+  "modulesContent": {
+    "$edgeAgent": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "runtime": {
+          "type": "docker",
+          "settings": {
+            "minDockerVersion": "v1.25",
+            "loggingOptions": "",
+            "registryCredentials": {
+              "jiriatest": {
+                "username": "d3e6e3bc-2e38-4887-9073-2cf796462b15",
+                "password": "71181f94-a9b9-4b98-96a8-01c4ae8dff94",
+                "address": "edgeshared.azurecr.io"
+              },
+              "ACR_NAME": {
+                "username": "ACR_USER",
+                "password": "ACR_PASSWORD",
+                "address": "ACR_ADDRESS"
+              }
+            }
+          }
+        },
+        "systemModules": {
+          "edgeAgent": {
+            "type": "docker",
+            "settings": {
+              "image": "edgeshared.azurecr.io/microsoft/azureiotedge-agent:1809_insider-windows-amd64",
+              "createOptions": ""
+            }
+          },
+          "edgeHub": {
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "edgeshared.azurecr.io/microsoft/azureiotedge-hub:1809_insider-windows-amd64",
+              "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
+            }
+          }
+        },
+        "modules": {
+          "serialioports": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "ACR_IMAGE",
+              "createOptions": "{\"HostConfig\":{\"Devices\":[{\"CgroupPermissions\":\"\",\"PathInContainer\":\"\",\"PathOnHost\":\"class/86E0D1E0-8089-11D0-9CE4-08003E301F73\"}],\"Isolation\":\"Process\"}}"
+            }
+          }
+        }
+      }
+    },
+    "$edgeHub": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "routes": {
+          "sensorToSampleModule": "FROM /messages/modules/serialwin32/outputs/temperatureOutput INTO $upstream"
+        },
+        "storeAndForwardConfiguration": {
+          "timeToLiveSecs": 7200
+        }
+      }
+    }
+  }
+}

--- a/Samples/EdgeModules/SerialIOPorts/CS/deployment.x64.json
+++ b/Samples/EdgeModules/SerialIOPorts/CS/deployment.x64.json
@@ -9,11 +9,6 @@
             "minDockerVersion": "v1.25",
             "loggingOptions": "",
             "registryCredentials": {
-              "jiriatest": {
-                "username": "d3e6e3bc-2e38-4887-9073-2cf796462b15",
-                "password": "71181f94-a9b9-4b98-96a8-01c4ae8dff94",
-                "address": "edgeshared.azurecr.io"
-              },
               "ACR_NAME": {
                 "username": "ACR_USER",
                 "password": "ACR_PASSWORD",
@@ -26,7 +21,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "edgeshared.azurecr.io/microsoft/azureiotedge-agent:1809_insider-windows-amd64",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
               "createOptions": ""
             }
           },
@@ -35,7 +30,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "edgeshared.azurecr.io/microsoft/azureiotedge-hub:1809_insider-windows-amd64",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             }
           }

--- a/Samples/EdgeModules/SerialIOPorts/README.md
+++ b/Samples/EdgeModules/SerialIOPorts/README.md
@@ -1,0 +1,7 @@
+# USB Serial Access in an Azure IoT Edge module on Windows
+
+These are the available versions of this Azure IoT Edge module sample:
+
+*	[C#](./CS/README.md)
+
+This project has adopted the Microsoft Open Source Code of Conduct. For more information see the Code of Conduct FAQ or contact <opencode@microsoft.com> with any additional questions or comments.


### PR DESCRIPTION
# USB Serial Access in an Azure IoT Edge module on Windows

This sample will walk you through creating a module for Azure IoT Edge on Windows 10 IoT Enterprise which accesses a USB Serial device.

## API Surface

This sample uses standard .NET Core System.IO.Ports APIs to access the serial devices. 
These APIs only work with serial devices which come named "COM{x}".
Consequently, this approach is relevant on Windows 10 IoT Enterprise, but not Windows 10 IoT Core.
