### PR TITLE
Fix csharp snippets language

### DIFF
--- a/Demos/Kegocnizer/Keg.Azure.md
+++ b/Demos/Kegocnizer/Keg.Azure.md
@@ -129,7 +129,7 @@ e. Testing Azure Methods Created above
     
     Sample Output:
     
-``` C#
+```csharp
 2018-05-22T21:19:44 No new trace in the past 1 min(s). 
 2018-05-22T21:20:31.240 [Info] Script for function 'AddConfig' changed. Reloading. 
 2018-05-22T21:20:31.459 [Info] Compilation succeeded. 
@@ -170,7 +170,7 @@ g. Getting the KegConfig
 
 Method: AddConfig
 
-``` C#
+```csharp
 #r "Newtonsoft.Json"
 
 using System;
@@ -219,7 +219,7 @@ public class KegConfig
 
 Method: AddUser
 
-``` C#
+```csharp
 #r "Newtonsoft.Json"
 
 using System;
@@ -250,7 +250,7 @@ public class KegUser
 
 Method: GetUser
 
-``` C#
+```csharp
 using System.Net;
 
 public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log, IEnumerable<dynamic> items)

--- a/Samples/Accelerometer/CS/README.md
+++ b/Samples/Accelerometer/CS/README.md
@@ -116,7 +116,7 @@ A schematic for the circuit is:
 
 When everything is set up, power your device back on, and open up the sample app in Visual Studio. Open the file **MainPage.xaml.cs** and change the following line from **Protocol.NONE** to **Protocol.SPI**:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
     /* Important! Change this to either Protocol.I2C or Protocol.SPI based on how your accelerometer is wired   */
@@ -146,7 +146,7 @@ Let's start by digging into the initializations.
 ### Initialize the SPI bus
 To use the accelerometer, we need to initialize the SPI bus first. Here is the C# code.
 
-``` C#
+```csharp
 using Windows.Devices.Enumeration;
 using Windows.Devices.Spi;
 
@@ -195,7 +195,7 @@ Higher G settings provide you with greater range at the expense of reduced resol
 
 2. We write a 0x08 to the power control register, which wakes the device from standby and starts measuring acceleration. Again, the [datasheet](https://www.sparkfun.com/datasheets/Sensors/Accelerometer/ADXL345.pdf){:target="_blank"} contains additional information about the device settings and capabilities.
 
-``` C#
+```csharp
 private async void InitSPIAccel()
 {
     // ...
@@ -229,7 +229,7 @@ private async void InitSPIAccel()
 
 ### Timer code
 After all the initializations are complete, we start a timer to read from the accelerometer periodically. Here is how you set up the timer to trigger every 100mS.
-``` C#
+```csharp
 private async void InitSPIAccel()
 {
     // ...
@@ -262,7 +262,7 @@ private void TimerCallback(object state)
 ### Read data from the accelerometer
 With the SPI bus and accelerometer initialized, we can start reading data from the accelerometer. Our **ReadAccel()** function gets called every 100mS by the timer:
 
-``` C#
+```csharp
 private Acceleration ReadAccel()
 {
     const int ACCEL_RES = 1024;         /* The ADXL345 has 10 bit resolution giving 1024 unique values                     */

--- a/Samples/Accelerometer/README.md
+++ b/Samples/Accelerometer/README.md
@@ -126,7 +126,7 @@ A schematic for the circuit is:
 
 When everything is set up, power your device back on, and open up the sample app in Visual Studio. Open the file **MainPage.xaml.cs** and change the following line from **Protocol.NONE** to **Protocol.SPI**:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
     /* Important! Change this to either Protocol.I2C or Protocol.SPI based on how your accelerometer is wired   */
@@ -156,7 +156,7 @@ Let's start by digging into the initializations.
 ### Initialize the SPI bus
 To use the accelerometer, we need to initialize the SPI bus first. Here is the C# code.
 
-``` C#
+```csharp
 using Windows.Devices.Enumeration;
 using Windows.Devices.Spi;
 
@@ -205,7 +205,7 @@ Higher G settings provide you with greater range at the expense of reduced resol
 
 2. We write a 0x08 to the power control register, which wakes the device from standby and starts measuring acceleration. Again, the [datasheet](https://www.sparkfun.com/datasheets/Sensors/Accelerometer/ADXL345.pdf){:target="_blank"} contains additional information about the device settings and capabilities.
 
-``` C#
+```csharp
 private async void InitSPIAccel()
 {
     // ...
@@ -239,7 +239,7 @@ private async void InitSPIAccel()
 
 ### Timer code
 After all the initializations are complete, we start a timer to read from the accelerometer periodically. Here is how you set up the timer to trigger every 100mS.
-``` C#
+```csharp
 private async void InitSPIAccel()
 {
     // ...
@@ -272,7 +272,7 @@ private void TimerCallback(object state)
 ### Read data from the accelerometer
 With the SPI bus and accelerometer initialized, we can start reading data from the accelerometer. Our **ReadAccel()** function gets called every 100mS by the timer:
 
-``` C#
+```csharp
 private Acceleration ReadAccel()
 {
     const int ACCEL_RES = 1024;         /* The ADXL345 has 10 bit resolution giving 1024 unique values                     */

--- a/Samples/AppServiceBlinky/CS/README.md
+++ b/Samples/AppServiceBlinky/CS/README.md
@@ -38,7 +38,7 @@ To add an appservice to our background application first we need to open appxman
 
 Next we'll add a check in the StartupTask::Run method to see if the application is being started as an appservice
 
-```C#
+```csharp
 //Check to determine whether this activation was caused by an incoming app service connection
 var appServiceTrigger = taskInstance.TriggerDetails as AppServiceTriggerDetails;
 if (appServiceTrigger != null)
@@ -59,14 +59,14 @@ if (appServiceTrigger != null)
 
 At the beginning of BlinkyService's StartupTask::Run get the deferral object and set up a Canceled event handler to clean up the deferral on exit.
 
-```C#
+```csharp
 deferral = taskInstance.GetDeferral();
 taskInstance.Canceled += TaskInstance_Canceled;
 ```
 
 When the Canceled event handler is called Complete the deferral for this instance of the app service if one exists.  If the deferral is not completed then the app service process will be killed by the operating system even if other clients still have connections open to the app service.
 
-```C#
+```csharp
 private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
 {
     if (deferral != null)
@@ -79,7 +79,7 @@ private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTas
 
 Finally we need to handle service requests:
 
-```C#
+```csharp
 private void Connection_RequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
 {
     var messageDeferral = args.GetDeferral();
@@ -122,7 +122,7 @@ private void Connection_RequestReceived(AppServiceConnection sender, AppServiceR
 ___
 When the client starts it opens a connection to the client.  The string assigned to connection.PackageFamilyName uniquely identifies the service we want to connect to.
 
-```C#
+```csharp
 AppServiceConnection connection;
 BackgroundTaskDeferral deferral;
 ThreadPoolTimer timer;
@@ -161,7 +161,7 @@ public async void Run(IBackgroundTaskInstance taskInstance)
 
 If everything connects without an error then the timer callback will toggle the value of the LED each time the timer event handler is called.
 
-```C#
+```csharp
 if (requestedPinValue.Equals("High"))
 {
     requestedPinValue = "Low";

--- a/Samples/AppServiceBlinky/README.md
+++ b/Samples/AppServiceBlinky/README.md
@@ -49,7 +49,7 @@ To add an appservice to our background application first we need to open appxman
 
 Next we'll add a check in the StartupTask::Run method to see if the application is being started as an appservice
 
-```C#
+```csharp
 //Check to determine whether this activation was caused by an incoming app service connection
 var appServiceTrigger = taskInstance.TriggerDetails as AppServiceTriggerDetails;
 if (appServiceTrigger != null)
@@ -70,14 +70,14 @@ if (appServiceTrigger != null)
 
 At the beginning of BlinkyService's StartupTask::Run get the deferral object and set up a Canceled event handler to clean up the deferral on exit.
 
-```C#
+```csharp
 deferral = taskInstance.GetDeferral();
 taskInstance.Canceled += TaskInstance_Canceled;
 ```
 
 When the Canceled event handler is called Complete the deferral for this instance of the app service if one exists.  If the deferral is not completed then the app service process will be killed by the operating system even if other clients still have connections open to the app service.
 
-```C#
+```csharp
 private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
 {
     if (deferral != null)
@@ -90,7 +90,7 @@ private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTas
 
 Finally we need to handle service requests:
 
-```C#
+```csharp
 private void Connection_RequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
 {
     var messageDeferral = args.GetDeferral();
@@ -133,7 +133,7 @@ private void Connection_RequestReceived(AppServiceConnection sender, AppServiceR
 ___
 When the client starts it opens a connection to the client.  The string assigned to connection.PackageFamilyName uniquely identifies the service we want to connect to.
 
-```C#
+```csharp
 AppServiceConnection connection;
 BackgroundTaskDeferral deferral;
 ThreadPoolTimer timer;
@@ -172,7 +172,7 @@ public async void Run(IBackgroundTaskInstance taskInstance)
 
 If everything connects without an error then the timer callback will toggle the value of the LED each time the timer event handler is called.
 
-```C#
+```csharp
 if (requestedPinValue.Equals("High"))
 {
     requestedPinValue = "Low";

--- a/Samples/AppServiceSharedNotepad/CS/README.md
+++ b/Samples/AppServiceSharedNotepad/CS/README.md
@@ -40,7 +40,7 @@ To add an appservice to our background application first we need to open appxman
 
 Next we'll add a check in the StartupTask::Run method to see if the application is being started as an appservice
 
-``` C#
+```csharp
 //Check to determine whether this activation was caused by an incoming app service connection
 var appServiceTrigger = taskInstance.TriggerDetails as AppServiceTriggerDetails;
 if (appServiceTrigger != null)
@@ -61,14 +61,14 @@ if (appServiceTrigger != null)
 
 At the beginning of NotepadService's StartupTask::Run get the deferral object and set up a Canceled event handler to clean up the deferral on exit.
 
-``` C#
+```csharp
 serviceDeferral = taskInstance.GetDeferral();
 taskInstance.Canceled += TaskInstance_Canceled;
 ```
 
 When the Canceled event handler is called Complete the deferral for this instance of the app service if one exists.  If the deferral is not completed then the app service process will be killed by the operating system even if other clients still have connections open to the app service.
 
-``` C#
+```csharp
 private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
 {
     if (deferral != null)
@@ -81,7 +81,7 @@ private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTas
 
 Finally we need to handle service requests:
 
-``` C#
+```csharp
 // This AppService supports recieving two types of request: "postNote" and "getMessages"
 // When a note is sent from the clients the service will pass it to the shared notepad
 // and send a confirmation response to the client.
@@ -115,7 +115,7 @@ private async void AppServiceConnection_RequestReceived(AppServiceConnection sen
 ___
 When the client starts it opens a connection to the client.  The string assigned to connection.PackageFamilyName uniquely identifies the service we want to connect to.
 
-``` C#
+```csharp
 AppServiceConnection connection;
 BackgroundTaskDeferral deferral;
 ThreadPoolTimer timer;
@@ -162,7 +162,7 @@ private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTas
 
 If everything connects without an error then the timer callback will post a new note every 30 seconds.
 
-``` C#
+```csharp
 public async void Tick(ThreadPoolTimer sender)
 {
     count++;
@@ -197,7 +197,7 @@ Also, add a button called **GetNewMessagesButton** to get messages from NotepadS
 
 In the **MainPage** constructor add an event handler for the **Loaded** event.  In the **Loaded** event handler connect to the **NotepadService** app service.
 
-``` C#
+```csharp
 AppServiceConnection connection;
 
 public MainPage()
@@ -232,7 +232,7 @@ private async void MainPage_Loaded(object sender, RoutedEventArgs e)
 
 When the NotepadService receives a new message it will call the connection's  **RequestReceived** event handler to notify the client application.  When a new message is received enable  **GetNewMessagesButton**.
 
-``` C#
+```csharp
 //When the service notifies us of new messages, enable the button to allow the user to request messages
 private async void Connection_RequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
 {
@@ -253,7 +253,7 @@ private async void Connection_RequestReceived(AppServiceConnection sender, AppSe
 
 When the **GetNewMessagesButton** is clicked request the message from **NotepadService** and display them in the **Messages** TextBlock.
 
-``` C#
+```csharp
 //When the user requests new messages, send a request to the server and print them out
 private async void GetNewMessagesButton_Click(object sender, RoutedEventArgs e)
 {

--- a/Samples/AppServiceSharedNotepad/README.md
+++ b/Samples/AppServiceSharedNotepad/README.md
@@ -50,7 +50,7 @@ To add an appservice to our background application first we need to open appxman
 
 Next we'll add a check in the StartupTask::Run method to see if the application is being started as an appservice
 
-``` C#
+```csharp
 //Check to determine whether this activation was caused by an incoming app service connection
 var appServiceTrigger = taskInstance.TriggerDetails as AppServiceTriggerDetails;
 if (appServiceTrigger != null)
@@ -71,14 +71,14 @@ if (appServiceTrigger != null)
 
 At the beginning of NotepadService's StartupTask::Run get the deferral object and set up a Canceled event handler to clean up the deferral on exit.
 
-``` C#
+```csharp
 serviceDeferral = taskInstance.GetDeferral();
 taskInstance.Canceled += TaskInstance_Canceled;
 ```
 
 When the Canceled event handler is called Complete the deferral for this instance of the app service if one exists.  If the deferral is not completed then the app service process will be killed by the operating system even if other clients still have connections open to the app service.
 
-``` C#
+```csharp
 private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
 {
     if (deferral != null)
@@ -91,7 +91,7 @@ private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTas
 
 Finally we need to handle service requests:
 
-``` C#
+```csharp
 // This AppService supports recieving two types of request: "postNote" and "getMessages"
 // When a note is sent from the clients the service will pass it to the shared notepad
 // and send a confirmation response to the client.
@@ -125,7 +125,7 @@ private async void AppServiceConnection_RequestReceived(AppServiceConnection sen
 ___
 When the client starts it opens a connection to the client.  The string assigned to connection.PackageFamilyName uniquely identifies the service we want to connect to.
 
-``` C#
+```csharp
 AppServiceConnection connection;
 BackgroundTaskDeferral deferral;
 ThreadPoolTimer timer;
@@ -172,7 +172,7 @@ private void TaskInstance_Canceled(IBackgroundTaskInstance sender, BackgroundTas
 
 If everything connects without an error then the timer callback will post a new note every 30 seconds.
 
-``` C#
+```csharp
 public async void Tick(ThreadPoolTimer sender)
 {
     count++;
@@ -207,7 +207,7 @@ Also, add a button called **GetNewMessagesButton** to get messages from NotepadS
 
 In the **MainPage** constructor add an event handler for the **Loaded** event.  In the **Loaded** event handler connect to the **NotepadService** app service.
 
-``` C#
+```csharp
 AppServiceConnection connection;
 
 public MainPage()
@@ -242,7 +242,7 @@ private async void MainPage_Loaded(object sender, RoutedEventArgs e)
 
 When the NotepadService receives a new message it will call the connection's  **RequestReceived** event handler to notify the client application.  When a new message is received enable  **GetNewMessagesButton**.
 
-``` C#
+```csharp
 //When the service notifies us of new messages, enable the button to allow the user to request messages
 private async void Connection_RequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
 {
@@ -263,7 +263,7 @@ private async void Connection_RequestReceived(AppServiceConnection sender, AppSe
 
 When the **GetNewMessagesButton** is clicked request the message from **NotepadService** and display them in the **Messages** TextBlock.
 
-``` C#
+```csharp
 //When the user requests new messages, send a request to the server and print them out
 private async void GetNewMessagesButton_Click(object sender, RoutedEventArgs e)
 {

--- a/Samples/CognitiveServicesExample/CS/README.md
+++ b/Samples/CognitiveServicesExample/CS/README.md
@@ -120,7 +120,7 @@ ___
 
 Open MainPage.xaml.cs. At the top of the , directly under the "using" statements and before the "namespace CognitiveServicesExample" line, add the following Cognitive Services namespaces.
 
-``` C#
+```csharp
 using Windows.Graphics.Imaging;
 using Microsoft.ProjectOxford.Emotion;
 using Microsoft.ProjectOxford.Emotion.Contract;
@@ -139,7 +139,7 @@ These allow us to use the Cognitive Services APIs in our code, along with some o
 
 Add the following global variables to the MainPage class (as below)
 
-```C#
+```csharp
 public sealed partial class MainPage : Page
 {
   // add these in after the above statement
@@ -155,7 +155,7 @@ The subscriptionKey allows your application to call the Emotion API on Cognitive
 
 Add the following method to the same class:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
   //...
@@ -194,7 +194,7 @@ This function instantiates an instance of the Emotion API and attempts to open t
 
 Add the **async** keyword to the button_Clicked method Visual Studio created for you. Then, add the following code to that function:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
   //...
@@ -253,7 +253,7 @@ This code reads the string from the text input box on the form and makes sure it
 
 You'll notice that the above code has errors, since we have not added those helper functions yet. Let's add them in:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
   //...

--- a/Samples/CognitiveServicesExample/README.md
+++ b/Samples/CognitiveServicesExample/README.md
@@ -130,7 +130,7 @@ ___
 
 Open MainPage.xaml.cs. At the top of the , directly under the "using" statements and before the "namespace CognitiveServicesExample" line, add the following Cognitive Services namespaces.
 
-``` C#
+```csharp
 using Windows.Graphics.Imaging;
 using Microsoft.ProjectOxford.Emotion;
 using Microsoft.ProjectOxford.Emotion.Contract;
@@ -149,7 +149,7 @@ These allow us to use the Cognitive Services APIs in our code, along with some o
 
 Add the following global variables to the MainPage class (as below)
 
-```C#
+```csharp
 public sealed partial class MainPage : Page
 {
   // add these in after the above statement
@@ -165,7 +165,7 @@ The subscriptionKey allows your application to call the Emotion API on Cognitive
 
 Add the following method to the same class:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
   //...
@@ -204,7 +204,7 @@ This function instantiates an instance of the Emotion API and attempts to open t
 
 Add the **async** keyword to the button_Clicked method Visual Studio created for you. Then, add the following code to that function:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
   //...
@@ -263,7 +263,7 @@ This code reads the string from the text input box on the form and makes sure it
 
 You'll notice that the above code has errors, since we have not added those helper functions yet. Let's add them in:
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
   //...

--- a/Samples/CustomDeviceAccessor/CPP/README.md
+++ b/Samples/CustomDeviceAccessor/CPP/README.md
@@ -211,7 +211,7 @@ If you do not control the driver code for your device, you can override the SDDL
 
 First, we need to convert the SDDL string to its binary representation. We can do this with [PowerShell](http://blogs.technet.com/b/heyscriptingguy/archive/2011/08/09/use-powershell-to-convert-sddl-to-binary-format.aspx). Open a PowerShell prompt and run the following commands:
 
-``` C#
+```csharp
     $a = ([wmiclass]"Win32_SecurityDescriptorHelper").SDDLToBinarySD("D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;AU)(A;;GA;;;AC)").BinarySD | % { '{0:X}' -f $_ }
     $a -join ','
 ```

--- a/Samples/CustomDeviceAccessor/README.md
+++ b/Samples/CustomDeviceAccessor/README.md
@@ -221,7 +221,7 @@ If you do not control the driver code for your device, you can override the SDDL
 
 First, we need to convert the SDDL string to its binary representation. We can do this with [PowerShell](http://blogs.technet.com/b/heyscriptingguy/archive/2011/08/09/use-powershell-to-convert-sddl-to-binary-format.aspx). Open a PowerShell prompt and run the following commands:
 
-``` C#
+```csharp
     $a = ([wmiclass]"Win32_SecurityDescriptorHelper").SDDLToBinarySD("D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;AU)(A;;GA;;;AC)").BinarySD | % { '{0:X}' -f $_ }
     $a -join ','
 ```

--- a/Samples/ExternalProcessLauncher/CS/README.md
+++ b/Samples/ExternalProcessLauncher/CS/README.md
@@ -81,7 +81,7 @@ The `ProcessLauncher` API providers a number of static method overloads to launc
 
 Here's the part of the sample that launches the new process. After the process is launched, we `await` its return to get the exit code.
 
-``` C#   
+```csharp   
 var result = await ProcessLauncher.RunToCompletionAsync(cmd.Text, args.Text == null ? string.Empty : args.Text, options);
 
 ProcessExitCode.Text += "Process Exit Code: " + result.ExitCode;
@@ -102,7 +102,7 @@ To be able to both read and write data to strams, we create the streams as `Wind
 
 Here's the relavant code from the sample. First, we initialize the stream objects:
 
-``` C#   
+```csharp   
 var options = new ProcessLauncherOptions();
 var standardOutput = new InMemoryRandomAccessStream();
 var standardError = new InMemoryRandomAccessStream();
@@ -112,13 +112,13 @@ options.StandardError = standardError;
 
 Then, we pass the options to the `RunToCompletionAsync()` method:
 
-``` C#   
+```csharp   
 var result = await ProcessLauncher.RunToCompletionAsync(cmd.Text, args.Text == null ? string.Empty : args.Text, options);
 ``` 
 
 Finally, we read the data from the `InMemoryRandomAccessStream` after getting it as an input stream:
 
-``` C#   
+```csharp   
 using (var outStreamRedirect = standardOutput.GetInputStreamAt(0))
 {
     var size = standardOutput.Size;

--- a/Samples/ExternalProcessLauncher/README.md
+++ b/Samples/ExternalProcessLauncher/README.md
@@ -91,7 +91,7 @@ The `ProcessLauncher` API providers a number of static method overloads to launc
 
 Here's the part of the sample that launches the new process. After the process is launched, we `await` its return to get the exit code.
 
-``` C#   
+```csharp   
 var result = await ProcessLauncher.RunToCompletionAsync(cmd.Text, args.Text == null ? string.Empty : args.Text, options);
 
 ProcessExitCode.Text += "Process Exit Code: " + result.ExitCode;
@@ -112,7 +112,7 @@ To be able to both read and write data to strams, we create the streams as `Wind
 
 Here's the relavant code from the sample. First, we initialize the stream objects:
 
-``` C#   
+```csharp   
 var options = new ProcessLauncherOptions();
 var standardOutput = new InMemoryRandomAccessStream();
 var standardError = new InMemoryRandomAccessStream();
@@ -122,13 +122,13 @@ options.StandardError = standardError;
 
 Then, we pass the options to the `RunToCompletionAsync()` method:
 
-``` C#   
+```csharp   
 var result = await ProcessLauncher.RunToCompletionAsync(cmd.Text, args.Text == null ? string.Empty : args.Text, options);
 ``` 
 
 Finally, we read the data from the `InMemoryRandomAccessStream` after getting it as an input stream:
 
-``` C#   
+```csharp   
 using (var outStreamRedirect = standardOutput.GetInputStreamAt(0))
 {
     var size = standardOutput.Size;

--- a/Samples/FlowVolume/CS/README.md
+++ b/Samples/FlowVolume/CS/README.md
@@ -65,7 +65,7 @@ By counting the number of pulses and multiplying by a factor, the volume flowing
 
 Here is how you set up the application to use the Flow object in C#:
 
-``` C#
+```csharp
 public MainPage()
 {
     this.InitializeComponent();

--- a/Samples/FlowVolume/README.md
+++ b/Samples/FlowVolume/README.md
@@ -75,7 +75,7 @@ By counting the number of pulses and multiplying by a factor, the volume flowing
 
 Here is how you set up the application to use the Flow object in C#:
 
-``` C#
+```csharp
 public MainPage()
 {
     this.InitializeComponent();

--- a/Samples/GpioOneWire/CPP/ReadMe.md
+++ b/Samples/GpioOneWire/CPP/ReadMe.md
@@ -65,7 +65,7 @@ consider bits to be 1s, while we will consider pulses shorter
 than this threshold to be 0s. We convert 110 microseconds to
 QueryPerformanceCounter (QPC) units to be used later.
 
-``` C#
+```csharp
 	HRESULT GpioOneWire::Dht11::Sample (GpioOneWire::Dht11Reading& Reading)
 	{
 		Reading = Dht11Reading();
@@ -86,7 +86,7 @@ is normally pulled high while the device is idle, and we must pull it low
 for 18 milliseconds to request a sample. We latch a low value to the pin
 and set it as an output, driving the GPIO pin low.
 
-``` C#
+```csharp
     // Latch low value onto pin
     this->pin->Write(GpioPinValue::Low);
 
@@ -100,7 +100,7 @@ and set it as an output, driving the GPIO pin low.
 We then revert the pin to an input which causes it to go high, and wait for
 the DHT11 to pull the pin low, then high again.
 
-``` C#
+```csharp
     // Set pin back to input
     this->pin->SetDriveMode(this->inputDriveMode);
 
@@ -129,7 +129,7 @@ After receiving the first rising edge, we catch all of the falling edges
 and measure the time difference between them to determine whether the bit
 is a 0 or 1.
 
-``` C#
+```csharp
     LARGE_INTEGER prevTime = { 0 };
 
     const ULONG sampleTimeoutMillis = 10;
@@ -167,7 +167,7 @@ After all bits have been received, we validate the checksum to make sure the
 received data is valid. The data is returned through the `Reading` reference
 parameter.
 
-``` C#
+```csharp
     if (!Reading.IsValid()) {
         // checksum mismatch
         return HRESULT_FROM_WIN32(ERROR_INVALID_DATA);

--- a/Samples/GpioOneWire/ReadMe.md
+++ b/Samples/GpioOneWire/ReadMe.md
@@ -107,7 +107,7 @@ consider bits to be 1s, while we will consider pulses shorter
 than this threshold to be 0s. We convert 110 microseconds to
 QueryPerformanceCounter (QPC) units to be used later.
 
-``` C#
+```csharp
 	HRESULT GpioOneWire::Dht11::Sample (GpioOneWire::Dht11Reading& Reading)
 	{
 		Reading = Dht11Reading();
@@ -128,7 +128,7 @@ is normally pulled high while the device is idle, and we must pull it low
 for 18 milliseconds to request a sample. We latch a low value to the pin
 and set it as an output, driving the GPIO pin low.
 
-``` C#
+```csharp
     // Latch low value onto pin
     this->pin->Write(GpioPinValue::Low);
 
@@ -142,7 +142,7 @@ and set it as an output, driving the GPIO pin low.
 We then revert the pin to an input which causes it to go high, and wait for
 the DHT11 to pull the pin low, then high again.
 
-``` C#
+```csharp
     // Set pin back to input
     this->pin->SetDriveMode(this->inputDriveMode);
 
@@ -171,7 +171,7 @@ After receiving the first rising edge, we catch all of the falling edges
 and measure the time difference between them to determine whether the bit
 is a 0 or 1.
 
-``` C#
+```csharp
     LARGE_INTEGER prevTime = { 0 };
 
     const ULONG sampleTimeoutMillis = 10;
@@ -209,7 +209,7 @@ After all bits have been received, we validate the checksum to make sure the
 received data is valid. The data is returned through the `Reading` reference
 parameter.
 
-``` C#
+```csharp
     if (!Reading.IsValid()) {
         // checksum mismatch
         return HRESULT_FROM_WIN32(ERROR_INVALID_DATA);

--- a/Samples/HelloBlinkyBackground/CPP/README.md
+++ b/Samples/HelloBlinkyBackground/CPP/README.md
@@ -29,7 +29,7 @@ The code for this sample is pretty simple. We use a timer, and each time the 'Ti
 ## Timer code
 ___
 Here is how you set up the timer in C#:
-``` C#
+```csharp
 using Windows.System.Threading;
 
 BackgroundTaskDeferral _deferral;
@@ -52,7 +52,7 @@ private void Timer_Tick(ThreadPoolTimer timer)
 ___
 To drive the GPIO pin, first we need to initialize it. Here is the C# code (notice how we leverage the new WinRT classes in the Windows.Devices.Gpio namespace):
 
-``` C#
+```csharp
 using Windows.Devices.Gpio;
 
 private void InitGPIO()
@@ -96,13 +96,13 @@ Once we have access to the `GpioOutputPin` instance, it's trivial to change the 
 
 To turn the LED on, simply write the value `GpioPinValue.Low` to the pin:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.Low);
 ```
 
 and of course, write `GpioPinValue.High` to turn the LED off:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.High);
 ```
 

--- a/Samples/HelloBlinkyBackground/CS/README.md
+++ b/Samples/HelloBlinkyBackground/CS/README.md
@@ -29,7 +29,7 @@ The code for this sample is pretty simple. We use a timer, and each time the 'Ti
 ## Timer code
 ___
 Here is how you set up the timer in C#:
-``` C#
+```csharp
 using Windows.System.Threading;
 
 BackgroundTaskDeferral _deferral;
@@ -52,7 +52,7 @@ private void Timer_Tick(ThreadPoolTimer timer)
 ___
 To drive the GPIO pin, first we need to initialize it. Here is the C# code (notice how we leverage the new WinRT classes in the Windows.Devices.Gpio namespace):
 
-``` C#
+```csharp
 using Windows.Devices.Gpio;
 
 private void InitGPIO()
@@ -96,13 +96,13 @@ Once we have access to the `GpioOutputPin` instance, it's trivial to change the 
 
 To turn the LED on, simply write the value `GpioPinValue.Low` to the pin:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.Low);
 ```
 
 and of course, write `GpioPinValue.High` to turn the LED off:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.High);
 ```
 

--- a/Samples/HelloBlinkyBackground/README.md
+++ b/Samples/HelloBlinkyBackground/README.md
@@ -41,7 +41,7 @@ The code for this sample is pretty simple. We use a timer, and each time the 'Ti
 ## Timer code
 ___
 Here is how you set up the timer in C#:
-``` C#
+```csharp
 using Windows.System.Threading;
 
 BackgroundTaskDeferral _deferral;
@@ -64,7 +64,7 @@ private void Timer_Tick(ThreadPoolTimer timer)
 ___
 To drive the GPIO pin, first we need to initialize it. Here is the C# code (notice how we leverage the new WinRT classes in the Windows.Devices.Gpio namespace):
 
-``` C#
+```csharp
 using Windows.Devices.Gpio;
 
 private void InitGPIO()
@@ -108,13 +108,13 @@ Once we have access to the `GpioOutputPin` instance, it's trivial to change the 
 
 To turn the LED on, simply write the value `GpioPinValue.Low` to the pin:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.Low);
 ```
 
 and of course, write `GpioPinValue.High` to turn the LED off:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.High);
 ```
 

--- a/Samples/HelloBlinkyBackground/VB/README.md
+++ b/Samples/HelloBlinkyBackground/VB/README.md
@@ -29,7 +29,7 @@ The code for this sample is pretty simple. We use a timer, and each time the 'Ti
 ## Timer code
 ___
 Here is how you set up the timer in C#:
-``` C#
+```csharp
 using Windows.System.Threading;
 
 BackgroundTaskDeferral _deferral;
@@ -52,7 +52,7 @@ private void Timer_Tick(ThreadPoolTimer timer)
 ___
 To drive the GPIO pin, first we need to initialize it. Here is the C# code (notice how we leverage the new WinRT classes in the Windows.Devices.Gpio namespace):
 
-``` C#
+```csharp
 using Windows.Devices.Gpio;
 
 private void InitGPIO()
@@ -96,13 +96,13 @@ Once we have access to the `GpioOutputPin` instance, it's trivial to change the 
 
 To turn the LED on, simply write the value `GpioPinValue.Low` to the pin:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.Low);
 ```
 
 and of course, write `GpioPinValue.High` to turn the LED off:
 
-``` C#
+```csharp
 this.pin.Write(GpioPinValue.High);
 ```
 

--- a/Samples/HelloWorld/CS/README.md
+++ b/Samples/HelloWorld/CS/README.md
@@ -49,7 +49,7 @@ Now that we have a TextBox and a Button, we can add some code which will be exec
 ```
   
 *MainPage.xaml.cs:*
-``` C#
+```csharp
 private void ClickMe_Click(object sender, RoutedEventArgs e)
 {
     this.HelloMessage.Text = "Hello, Windows 10 IoT Core!";

--- a/Samples/HelloWorld/README.md
+++ b/Samples/HelloWorld/README.md
@@ -59,7 +59,7 @@ Now that we have a TextBox and a Button, we can add some code which will be exec
 ```
   
 *MainPage.xaml.cs:*
-``` C#
+```csharp
 private void ClickMe_Click(object sender, RoutedEventArgs e)
 {
     this.HelloMessage.Text = "Hello, Windows 10 IoT Core!";

--- a/Samples/I2cPortExpander/CS/README.md
+++ b/Samples/I2cPortExpander/CS/README.md
@@ -157,7 +157,7 @@ Let's add some content to the MainPage which will be displayed on a screen conne
 
 * Locate the `<Grid>` tag in the XAML section of the designer, and add the following markup:
 
-``` C#
+```csharp
 <Grid Background="Black">
     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
         <Ellipse x:Name="Led" Fill="LightGray" Stroke="White" Width="100" Height="100" Margin="10"/>
@@ -182,7 +182,7 @@ Before we add any code to MainPage.xaml.cs, we need to add a reference to the Wi
 
  * Add the following lines at the top of MainPage.xaml.cs
 
-``` C#
+```csharp
 using Windows.Devices.Enumeration;
 using Windows.Devices.I2c;
 ```
@@ -193,7 +193,7 @@ With the references added, let's start adding code. The complete code we impleme
 
 Variables and Constants
 
-``` C#
+```csharp
 // use these constants for controlling how the I2C bus is setup
 private const string I2C_CONTROLLER_NAME = "I2C1"; //specific to RPi2 or RPi3
 private const byte PORT_EXPANDER_I2C_ADDRESS = 0x20; // 7-bit I2C address of the port expander
@@ -251,7 +251,7 @@ The method `InitializeSystem()`
 
 When complete, the variable `i2cPortExpander` will be our handle to the Raspberry Pi 2 or 3 I2C bus.
 
-``` C#
+```csharp
 private async void InitializeSystem()
 {
     byte[] i2CWriteBuffer;
@@ -339,7 +339,7 @@ The method `FlipLED()`
 
  * If the LED is currently on, it sends commands to the port expander to turn the LED off and sets the color of the circle on the display to gray.
 
-``` C#
+```csharp
 private void FlipLED()
 {
     byte bitMask;
@@ -371,7 +371,7 @@ private void FlipLED()
 
 This method updates the text in Textbox displayed to the screen to reflect the status of the switch.
 
-``` C#
+```csharp
 private void CheckButtonStatus()
 {
     byte[] readBuffer = new byte[1];
@@ -407,7 +407,7 @@ Congratulations! You've successfully connected an I2C port expander to your Rasp
 
 ### The complete MainPage.xaml.cs code
 
-``` C#
+```csharp
 using System;
 //using System.Diagnostics;
 using System.Collections.Generic;

--- a/Samples/I2cPortExpander/README.md
+++ b/Samples/I2cPortExpander/README.md
@@ -167,7 +167,7 @@ Let's add some content to the MainPage which will be displayed on a screen conne
 
 * Locate the `<Grid>` tag in the XAML section of the designer, and add the following markup:
 
-``` C#
+```csharp
 <Grid Background="Black">
     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
         <Ellipse x:Name="Led" Fill="LightGray" Stroke="White" Width="100" Height="100" Margin="10"/>
@@ -192,7 +192,7 @@ Before we add any code to MainPage.xaml.cs, we need to add a reference to the Wi
 
  * Add the following lines at the top of MainPage.xaml.cs
 
-``` C#
+```csharp
 using Windows.Devices.Enumeration;
 using Windows.Devices.I2c;
 ```
@@ -203,7 +203,7 @@ With the references added, let's start adding code. The complete code we impleme
 
 Variables and Constants
 
-``` C#
+```csharp
 // use these constants for controlling how the I2C bus is setup
 private const string I2C_CONTROLLER_NAME = "I2C1"; //specific to RPi2 or RPi3
 private const byte PORT_EXPANDER_I2C_ADDRESS = 0x20; // 7-bit I2C address of the port expander
@@ -261,7 +261,7 @@ The method `InitializeSystem()`
 
 When complete, the variable `i2cPortExpander` will be our handle to the Raspberry Pi 2 or 3 I2C bus.
 
-``` C#
+```csharp
 private async void InitializeSystem()
 {
     byte[] i2CWriteBuffer;
@@ -349,7 +349,7 @@ The method `FlipLED()`
 
  * If the LED is currently on, it sends commands to the port expander to turn the LED off and sets the color of the circle on the display to gray.
 
-``` C#
+```csharp
 private void FlipLED()
 {
     byte bitMask;
@@ -381,7 +381,7 @@ private void FlipLED()
 
 This method updates the text in Textbox displayed to the screen to reflect the status of the switch.
 
-``` C#
+```csharp
 private void CheckButtonStatus()
 {
     byte[] readBuffer = new byte[1];
@@ -417,7 +417,7 @@ Congratulations! You've successfully connected an I2C port expander to your Rasp
 
 ### The complete MainPage.xaml.cs code
 
-``` C#
+```csharp
 using System;
 //using System.Diagnostics;
 using System.Collections.Generic;

--- a/Samples/IoTCoreMediaPlayer/CS/README.md
+++ b/Samples/IoTCoreMediaPlayer/CS/README.md
@@ -31,7 +31,7 @@ The user is able to browse for a media file stored on the device by clicking on 
 
 Once a media file is selected, the sample sets the media using this instruction in MainPage.xaml.cs:
 
-``` C#
+```csharp
 	mediaElement.SetSource(stream, Picker_SelectedFile.ContentType);
 ```
 For more information and documentation about the MediaElement object, see [MediaElement Class](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.MediaElement) documentation.

--- a/Samples/IoTCoreMediaPlayer/README.md
+++ b/Samples/IoTCoreMediaPlayer/README.md
@@ -41,7 +41,7 @@ The user is able to browse for a media file stored on the device by clicking on 
 
 Once a media file is selected, the sample sets the media using this instruction in MainPage.xaml.cs:
 
-``` C#
+```csharp
 	mediaElement.SetSource(stream, Picker_SelectedFile.ContentType);
 ```
 For more information and documentation about the MediaElement object, see [MediaElement Class](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.MediaElement) documentation.

--- a/Samples/IoTOnboarding_RFCOMM/CS/README.md
+++ b/Samples/IoTOnboarding_RFCOMM/CS/README.md
@@ -34,14 +34,14 @@ The general communication flow between Client and Server
 1. On your Manager Device, go to *Settings* > *About* to get the **Device Name** under *Device Specifications*.
 2. Open the "Client" solution in Visual Studio 2017 on your Dev Machine.
 3. Open **SampleConfiguration.cs**, find the line
-    ```C#
+    ```csharp
     public const string TARGET_NAME = "<DESKTOP_NAME>";
     ```
     and replace `<DESKTOP_NAME>` with **Device Name** of your Manager Device.
 4. If you have only one network adapter on your IoT Device, skip to Step 5. Otherwise:
     1. Open **NetworkManager.cs**, and Search for `//TODO:`.
     2. Edit the the following section to find your targeted network adatper:
-        ```C#
+        ```csharp
         //Get the first WiFi adatper from the list. 
         //TODO: Edit this part if the system has more than one WiFi adatpers.
         m_wiFiAdapter = m_wiFiAdapterList[0];

--- a/Samples/IoTOnboarding_RFCOMM/README.md
+++ b/Samples/IoTOnboarding_RFCOMM/README.md
@@ -44,14 +44,14 @@ The general communication flow between Client and Server
 1. On your Manager Device, go to *Settings* > *About* to get the **Device Name** under *Device Specifications*.
 2. Open the "Client" solution in Visual Studio 2017 on your Dev Machine.
 3. Open **SampleConfiguration.cs**, find the line
-    ```C#
+    ```csharp
     public const string TARGET_NAME = "<DESKTOP_NAME>";
     ```
     and replace `<DESKTOP_NAME>` with **Device Name** of your Manager Device.
 4. If you have only one network adapter on your IoT Device, skip to Step 5. Otherwise:
     1. Open **NetworkManager.cs**, and Search for `//TODO:`.
     2. Edit the the following section to find your targeted network adatper:
-        ```C#
+        ```csharp
         //Get the first WiFi adatper from the list. 
         //TODO: Edit this part if the system has more than one WiFi adatpers.
         m_wiFiAdapter = m_wiFiAdapterList[0];

--- a/Samples/PotentiometerSensor/CS/README.md
+++ b/Samples/PotentiometerSensor/CS/README.md
@@ -151,7 +151,7 @@ The code here performs two main tasks:
 
 Let's start by digging into the initializations. The first thing we initialize is the GPIO LED pin in **InitGPIO()**.
 
-``` C#
+```csharp
 private void InitGpio()
 {
 	var gpio = GpioController.GetDefault();
@@ -178,7 +178,7 @@ private void InitGpio()
 
 Next, we initialize the SPI bus. This allows the RPi2 or RPi3 to communicate with the ADC to read in potentiometer positions.
 
-``` C#
+```csharp
 private async Task InitSPI()
 {
 	try
@@ -211,7 +211,7 @@ private async Task InitSPI()
 
 After the initializations are complete, we create a periodic timer to read data every 100mS.
 
-``` C#
+```csharp
 private async void InitAll()
 {
 	// ...
@@ -225,7 +225,7 @@ private async void InitAll()
 
 This timer calls the **Timer_Tick()** function. Which starts by reading from the ADC:
 
-``` C#
+```csharp
 public void ReadADC()
 {
 	byte[] readBuffer = new byte[3]; /* Buffer to hold read data*/
@@ -263,7 +263,7 @@ public void ReadADC()
 
 Next, we control the LED based on the ADC result
 
-``` C#
+```csharp
 /* Turn on/off the LED depending on the potentiometer position    */
 private void LightLED()
 {

--- a/Samples/PotentiometerSensor/README.md
+++ b/Samples/PotentiometerSensor/README.md
@@ -161,7 +161,7 @@ The code here performs two main tasks:
 
 Let's start by digging into the initializations. The first thing we initialize is the GPIO LED pin in **InitGPIO()**.
 
-``` C#
+```csharp
 private void InitGpio()
 {
 	var gpio = GpioController.GetDefault();
@@ -188,7 +188,7 @@ private void InitGpio()
 
 Next, we initialize the SPI bus. This allows the RPi2 or RPi3 to communicate with the ADC to read in potentiometer positions.
 
-``` C#
+```csharp
 private async Task InitSPI()
 {
 	try
@@ -221,7 +221,7 @@ private async Task InitSPI()
 
 After the initializations are complete, we create a periodic timer to read data every 100mS.
 
-``` C#
+```csharp
 private async void InitAll()
 {
 	// ...
@@ -235,7 +235,7 @@ private async void InitAll()
 
 This timer calls the **Timer_Tick()** function. Which starts by reading from the ADC:
 
-``` C#
+```csharp
 public void ReadADC()
 {
 	byte[] readBuffer = new byte[3]; /* Buffer to hold read data*/
@@ -273,7 +273,7 @@ public void ReadADC()
 
 Next, we control the LED based on the ADC result
 
-``` C#
+```csharp
 /* Turn on/off the LED depending on the potentiometer position    */
 private void LightLED()
 {

--- a/Samples/PushButton/CS/README.md
+++ b/Samples/PushButton/CS/README.md
@@ -111,7 +111,7 @@ A schematic for the circuit is shown in the diagram below:
 
 Finally, the LED_PIN and BUTTON_PIN variables of the **MainPage.xaml.cs** file of the sample code will need the following modification:
 
-``` C#
+```csharp
 private const int LED_PIN = 13;
 private const int BUTTON_PIN = 36;
 ```
@@ -135,7 +135,7 @@ We'll be using the LED, connected to GPIO6, which is connected in
 active LOW configuration, meaning driving the pin HIGH will turn off the LED
 and driving the pin LOW will turn on the LED.
 
-``` C#
+```csharp
 buttonPin = gpio.OpenPin(BUTTON_PIN);
 ledPin = gpio.OpenPin(LED_PIN);
 ```
@@ -147,7 +147,7 @@ we initially open a pin, so we should always set the pin to a known state
 before changing it to an output. Remember that we connected the other end 
 of the LED to 3.3V, so we need to drive the pin to low to have current flow into the LED.
 
-``` C#
+```csharp
 // Initialize LED to the OFF state by first writing a HIGH value
 // We write HIGH because the LED is wired in a active LOW configuration
 ledPin.Write(GpioPinValue.High); 
@@ -158,7 +158,7 @@ Next, we set up the button pin. For the Raspberry Pi 2 or 3 or the DragonBoard 4
 built-in pull up resistors that we can activate. We use the built-in pull up resistor so that we don't need to supply a resistor externally. 
 The MinnowBoard Max has 10k&#x2126; pull-up resistors that are on by default and not configurable, so we insert a check to make sure this drive mode is supported.
 
-``` C#
+```csharp
 // Check if input pull-up resistors are supported
 if (buttonPin.IsDriveModeSupported(GpioPinDriveMode.InputPullUp))
 	buttonPin.SetDriveMode(GpioPinDriveMode.InputPullUp);
@@ -173,7 +173,7 @@ Buttons are mechanical devices and can make and break contact many times on a
 single button press. We don't want to be overwhelmed with events so we filter
 these out.
 
-``` C#
+```csharp
 // Set a debounce timeout to filter out switch bounce noise from a button press
 buttonPin.DebounceTimeout = TimeSpan.FromMilliseconds(50);
 
@@ -186,7 +186,7 @@ In the button interrupt handler, we look at the edge of the GPIO signal to
 determine whether the button was pressed or released. If the button was
 pressed, we flip the state of the LED.
 
-``` C#
+```csharp
 private void buttonPin_ValueChanged(GpioPin sender, GpioPinValueChangedEventArgs e)
 {
 	// toggle the state of the LED every time the button is pressed
@@ -203,7 +203,7 @@ pin, so we invoke an update operation on the UI thread. Capturing the result
 of an async method in a local variable is necessary to suppress a compiler
 warning when we don't want to wait for an asynchronous operation to complete.
 
-``` C#
+```csharp
 // need to invoke UI updates on the UI thread because this event
 // handler gets invoked on a separate thread.
 var task = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => {

--- a/Samples/PushButton/README.md
+++ b/Samples/PushButton/README.md
@@ -121,7 +121,7 @@ A schematic for the circuit is shown in the diagram below:
 
 Finally, the LED_PIN and BUTTON_PIN variables of the **MainPage.xaml.cs** file of the sample code will need the following modification:
 
-``` C#
+```csharp
 private const int LED_PIN = 13;
 private const int BUTTON_PIN = 36;
 ```
@@ -145,7 +145,7 @@ We'll be using the LED, connected to GPIO6, which is connected in
 active LOW configuration, meaning driving the pin HIGH will turn off the LED
 and driving the pin LOW will turn on the LED.
 
-``` C#
+```csharp
 buttonPin = gpio.OpenPin(BUTTON_PIN);
 ledPin = gpio.OpenPin(LED_PIN);
 ```
@@ -157,7 +157,7 @@ we initially open a pin, so we should always set the pin to a known state
 before changing it to an output. Remember that we connected the other end 
 of the LED to 3.3V, so we need to drive the pin to low to have current flow into the LED.
 
-``` C#
+```csharp
 // Initialize LED to the OFF state by first writing a HIGH value
 // We write HIGH because the LED is wired in a active LOW configuration
 ledPin.Write(GpioPinValue.High); 
@@ -168,7 +168,7 @@ Next, we set up the button pin. For the Raspberry Pi 2 or 3 or the DragonBoard 4
 built-in pull up resistors that we can activate. We use the built-in pull up resistor so that we don't need to supply a resistor externally. 
 The MinnowBoard Max has 10k&#x2126; pull-up resistors that are on by default and not configurable, so we insert a check to make sure this drive mode is supported.
 
-``` C#
+```csharp
 // Check if input pull-up resistors are supported
 if (buttonPin.IsDriveModeSupported(GpioPinDriveMode.InputPullUp))
 	buttonPin.SetDriveMode(GpioPinDriveMode.InputPullUp);
@@ -183,7 +183,7 @@ Buttons are mechanical devices and can make and break contact many times on a
 single button press. We don't want to be overwhelmed with events so we filter
 these out.
 
-``` C#
+```csharp
 // Set a debounce timeout to filter out switch bounce noise from a button press
 buttonPin.DebounceTimeout = TimeSpan.FromMilliseconds(50);
 
@@ -196,7 +196,7 @@ In the button interrupt handler, we look at the edge of the GPIO signal to
 determine whether the button was pressed or released. If the button was
 pressed, we flip the state of the LED.
 
-``` C#
+```csharp
 private void buttonPin_ValueChanged(GpioPin sender, GpioPinValueChangedEventArgs e)
 {
 	// toggle the state of the LED every time the button is pressed
@@ -213,7 +213,7 @@ pin, so we invoke an update operation on the UI thread. Capturing the result
 of an async method in a local variable is necessary to suppress a compiler
 warning when we don't want to wait for an asynchronous operation to complete.
 
-``` C#
+```csharp
 // need to invoke UI updates on the UI thread because this event
 // handler gets invoked on a separate thread.
 var task = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => {

--- a/Samples/RGBLED/CS/README.md
+++ b/Samples/RGBLED/CS/README.md
@@ -74,7 +74,7 @@ First, we get the default GPIO controller and check that it's not null.
 `GpioController.GetDefault()` will return null on platforms that do not contain
 a GPIO controller.
 
-``` C#
+```csharp
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             var gpio = GpioController.GetDefault();
@@ -95,7 +95,7 @@ located next to each other physically on the header. If we're not running on
 Raspberry Pi, we take the first 3 available pins. There is also logic to skip
 pins connected to onboard functions on known hardware platforms.
 
-``` C#
+```csharp
             var deviceModel = GetDeviceModel();
             if (deviceModel == DeviceModel.RaspberryPi2)
             {
@@ -151,7 +151,7 @@ Next, we initialize the pins as outputs driven HIGH, which causes the LED
 to be OFF. We also display which pin numbers are in use. If you're
 not using Raspberry Pi, hook up the RGB LED to the pins shown on the display.
 
-``` C#
+```csharp
             redpin.Write(GpioPinValue.High);
             redpin.SetDriveMode(GpioPinDriveMode.Output);
             greenpin.Write(GpioPinValue.High);
@@ -172,7 +172,7 @@ on the timer callback. If we did not need to update the UI, it would be better
 to use a `System.Threading.Timer` which runs on a separate thread. The less we
 can do on the UI thread, the more responsive the UI will be.
 
-``` C#
+```csharp
             timer = new DispatcherTimer();
             timer.Interval = TimeSpan.FromMilliseconds(500);
             timer.Tick += Timer_Tick;
@@ -182,7 +182,7 @@ can do on the UI thread, the more responsive the UI will be.
 
 In the timer callback, we light up the currently active LED and update the UI.
 
-``` C#
+```csharp
         private void FlipLED()
         {
             Debug.Assert(redpin != null && bluepin != null && greenpin != null);

--- a/Samples/SPIDisplay/CS/README.md
+++ b/Samples/SPIDisplay/CS/README.md
@@ -118,7 +118,7 @@ A schematic for the circuit is:
 
 When everything is set up, power your device back on, and open up the sample app in Visual Studio. Configure the code depending on which device you are using.
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
         /* Important! Uncomment the code below corresponding to your target device */
@@ -165,7 +165,7 @@ Let's start by digging into the initialization code first.
 ### Initialization Code
 Here is the C# code for the top-level initialization function.
 
-``` C#
+```csharp
 using Windows.Devices.Enumeration;
 using Windows.Devices.Spi;
 using Windows.Devices.Gpio;
@@ -224,7 +224,7 @@ Next, let's take a closer look at what each of the initialization functions is d
 There are two pins on the SPI OLED display we need to control, the Data/Command pin and the Reset pin. To communicate with these,
 we need to initialize the GPIO controller and configure the pins as outputs.
 
-``` C#
+```csharp
 /* Initialize the GPIO */
 private void InitGpio()
 {
@@ -262,7 +262,7 @@ private void InitGpio()
 Following the GPIO initialization, we initialize the SPI bus. The bus is used to send graphics data and commands to the OLED screen for display,
 and needs to be configured before we can talk to the display.
 
-``` C#
+```csharp
 /* Initialize the SPI bus */
 private async Task InitSpi()
 {
@@ -301,7 +301,7 @@ private async Task InitSpi()
 #### InitDisplay()
 Now that we have initialized GPIO and SPI, we can communicate with display. Before we can send graphics data however, we first need to configure some settings on the display controller.
 
-``` C#
+```csharp
 /* Send SPI commands to power up and initialize the display */
 private async Task InitDisplay()
 {
@@ -335,7 +335,7 @@ These commands turn the display on and put it into a state where it's ready to a
 Now that the display is initialized, we can send text to the screen. Previously in the initialization function, we registered **Display_TextBox_TextChanged()** to trigger any time the user changes the textbox.
 This function calls the **DisplayTextBoxContents()** function below which runs through the process of writing text out to the screen:
 
-``` C#
+```csharp
 /* Update the SPI display to mirror the textbox contents */
 private void DisplayTextBoxContents()
 {
@@ -376,7 +376,7 @@ In the following sections, we'll detail the **WriteCharDisplayBuf()** and **Disp
 The **WriteCharDisplayBuf()** function performs the work to convert a single character into an array of bytes representing the character image data.
 This function is frequently called by **WriteLineDisplayBuf()** to render individual characters in a string. Lets take a look at how it works.
 
-``` C#
+```csharp
 /*
  * NAME:        WriteCharDisplayBuf
  * DESCRIPTION: Writes one character to the display screen buffer (DisplayUpdate() needs to be called subsequently to output the buffer to the screen)
@@ -457,7 +457,7 @@ Again, all of this is happening in our local screen buffer. No data has been sen
 #### DisplayUpdate()
 After all of our data has been written to our local buffer. We're ready to write it out over SPI to the screen. For this, we call **DisplayUpdate()**:
 
-``` C#
+```csharp
 /* Writes the Display Buffer out to the physical screen for display */
 private void DisplayUpdate()
 {
@@ -486,7 +486,7 @@ we take horizontal "slices" of our display buffer and store them sequentially in
 
 * Finally, we call **DisplaySendData()** to send our buffer contents over SPI. This function is a wrapper around **SpiDevice.Write()**, which sends the entire buffer out over SPI.
 
-``` C#
+```csharp
 /* Send graphics data to the screen */
 private void DisplaySendData(byte[] Data)
 {

--- a/Samples/SPIDisplay/README.md
+++ b/Samples/SPIDisplay/README.md
@@ -128,7 +128,7 @@ A schematic for the circuit is:
 
 When everything is set up, power your device back on, and open up the sample app in Visual Studio. Configure the code depending on which device you are using.
 
-``` C#
+```csharp
 public sealed partial class MainPage : Page
 {
         /* Important! Uncomment the code below corresponding to your target device */
@@ -175,7 +175,7 @@ Let's start by digging into the initialization code first.
 ### Initialization Code
 Here is the C# code for the top-level initialization function.
 
-``` C#
+```csharp
 using Windows.Devices.Enumeration;
 using Windows.Devices.Spi;
 using Windows.Devices.Gpio;
@@ -234,7 +234,7 @@ Next, let's take a closer look at what each of the initialization functions is d
 There are two pins on the SPI OLED display we need to control, the Data/Command pin and the Reset pin. To communicate with these,
 we need to initialize the GPIO controller and configure the pins as outputs.
 
-``` C#
+```csharp
 /* Initialize the GPIO */
 private void InitGpio()
 {
@@ -272,7 +272,7 @@ private void InitGpio()
 Following the GPIO initialization, we initialize the SPI bus. The bus is used to send graphics data and commands to the OLED screen for display,
 and needs to be configured before we can talk to the display.
 
-``` C#
+```csharp
 /* Initialize the SPI bus */
 private async Task InitSpi()
 {
@@ -311,7 +311,7 @@ private async Task InitSpi()
 #### InitDisplay()
 Now that we have initialized GPIO and SPI, we can communicate with display. Before we can send graphics data however, we first need to configure some settings on the display controller.
 
-``` C#
+```csharp
 /* Send SPI commands to power up and initialize the display */
 private async Task InitDisplay()
 {
@@ -345,7 +345,7 @@ These commands turn the display on and put it into a state where it's ready to a
 Now that the display is initialized, we can send text to the screen. Previously in the initialization function, we registered **Display_TextBox_TextChanged()** to trigger any time the user changes the textbox.
 This function calls the **DisplayTextBoxContents()** function below which runs through the process of writing text out to the screen:
 
-``` C#
+```csharp
 /* Update the SPI display to mirror the textbox contents */
 private void DisplayTextBoxContents()
 {
@@ -386,7 +386,7 @@ In the following sections, we'll detail the **WriteCharDisplayBuf()** and **Disp
 The **WriteCharDisplayBuf()** function performs the work to convert a single character into an array of bytes representing the character image data.
 This function is frequently called by **WriteLineDisplayBuf()** to render individual characters in a string. Lets take a look at how it works.
 
-``` C#
+```csharp
 /*
  * NAME:        WriteCharDisplayBuf
  * DESCRIPTION: Writes one character to the display screen buffer (DisplayUpdate() needs to be called subsequently to output the buffer to the screen)
@@ -467,7 +467,7 @@ Again, all of this is happening in our local screen buffer. No data has been sen
 #### DisplayUpdate()
 After all of our data has been written to our local buffer. We're ready to write it out over SPI to the screen. For this, we call **DisplayUpdate()**:
 
-``` C#
+```csharp
 /* Writes the Display Buffer out to the physical screen for display */
 private void DisplayUpdate()
 {
@@ -496,7 +496,7 @@ we take horizontal "slices" of our display buffer and store them sequentially in
 
 * Finally, we call **DisplaySendData()** to send our buffer contents over SPI. This function is a wrapper around **SpiDevice.Write()**, which sends the entire buffer out over SPI.
 
-``` C#
+```csharp
 /* Send graphics data to the screen */
 private void DisplaySendData(byte[] Data)
 {

--- a/Samples/SerialUART/CPP/README.md
+++ b/Samples/SerialUART/CPP/README.md
@@ -203,7 +203,7 @@ You can add this by opening the **Package.appxmanifest** file in an XML editor (
 
 This sample app enumerates all serial devices connected to the device and displays the list in the **ListBox** ConnectDevices. The following code connects and configure the selected device ID and creates a **SerialDevice** object. 
 
-``` C#
+```csharp
 private async void comPortInput_Click(object sender, RoutedEventArgs e)
 {
     var selection = ConnectDevices.SelectedItems; // Get selected items from ListBox
@@ -243,7 +243,7 @@ Due to differences in handling concurrent tasks, the implementations of **Listen
 
 * C# allows awaiting **ReadAsync()**. All we do is keep reading the serial port in an infinite loop interrupted only when an exception is thrown (triggered by the cancellation token).
 
-``` C#
+```csharp
 
 private async void Listen()
 {
@@ -342,7 +342,7 @@ Concurrency::task<void> MainPage::ReadAsync(Concurrency::cancellation_token canc
 
 When the bytes are ready to be sent, we write asynchronously to the **OutputStream** of the **SerialDevice** object using the **DataWriter** object.
 
-``` C#
+```csharp
 private async void sendTextButton_Click(object sender, RoutedEventArgs e)
 {	
     // ...
@@ -379,7 +379,7 @@ private async Task WriteAsync()
 
 You can cancel the read operation by using **CancellationToken** on the Task. Initialize the **CancellationToken** object and pass that as an argument to the read task.
 
-``` C#
+```csharp
 
 private async void comPortInput_Click(object sender, RoutedEventArgs e)
 {
@@ -430,7 +430,7 @@ When closing the connection with the device, we cancel all pending I/O operation
 
 In this sample, we proceed to also refresh the list of devices connected.
 
-``` C#
+```csharp
 private void closeDevice_Click(object sender, RoutedEventArgs e)
 {
     try

--- a/Samples/SerialUART/CS/README.md
+++ b/Samples/SerialUART/CS/README.md
@@ -203,7 +203,7 @@ You can add this by opening the **Package.appxmanifest** file in an XML editor (
 
 This sample app enumerates all serial devices connected to the device and displays the list in the **ListBox** ConnectDevices. The following code connects and configure the selected device ID and creates a **SerialDevice** object. 
 
-``` C#
+```csharp
 private async void comPortInput_Click(object sender, RoutedEventArgs e)
 {
     var selection = ConnectDevices.SelectedItems; // Get selected items from ListBox
@@ -243,7 +243,7 @@ Due to differences in handling concurrent tasks, the implementations of **Listen
 
 * C# allows awaiting **ReadAsync()**. All we do is keep reading the serial port in an infinite loop interrupted only when an exception is thrown (triggered by the cancellation token).
 
-``` C#
+```csharp
 
 private async void Listen()
 {
@@ -342,7 +342,7 @@ Concurrency::task<void> MainPage::ReadAsync(Concurrency::cancellation_token canc
 
 When the bytes are ready to be sent, we write asynchronously to the **OutputStream** of the **SerialDevice** object using the **DataWriter** object.
 
-``` C#
+```csharp
 private async void sendTextButton_Click(object sender, RoutedEventArgs e)
 {	
     // ...
@@ -379,7 +379,7 @@ private async Task WriteAsync()
 
 You can cancel the read operation by using **CancellationToken** on the Task. Initialize the **CancellationToken** object and pass that as an argument to the read task.
 
-``` C#
+```csharp
 
 private async void comPortInput_Click(object sender, RoutedEventArgs e)
 {
@@ -430,7 +430,7 @@ When closing the connection with the device, we cancel all pending I/O operation
 
 In this sample, we proceed to also refresh the list of devices connected.
 
-``` C#
+```csharp
 private void closeDevice_Click(object sender, RoutedEventArgs e)
 {
     try

--- a/Samples/SerialUART/README.md
+++ b/Samples/SerialUART/README.md
@@ -213,7 +213,7 @@ You can add this by opening the **Package.appxmanifest** file in an XML editor (
 
 This sample app enumerates all serial devices connected to the device and displays the list in the **ListBox** ConnectDevices. The following code connects and configure the selected device ID and creates a **SerialDevice** object. 
 
-``` C#
+```csharp
 private async void comPortInput_Click(object sender, RoutedEventArgs e)
 {
     var selection = ConnectDevices.SelectedItems; // Get selected items from ListBox
@@ -253,7 +253,7 @@ Due to differences in handling concurrent tasks, the implementations of **Listen
 
 * C# allows awaiting **ReadAsync()**. All we do is keep reading the serial port in an infinite loop interrupted only when an exception is thrown (triggered by the cancellation token).
 
-``` C#
+```csharp
 
 private async void Listen()
 {
@@ -352,7 +352,7 @@ Concurrency::task<void> MainPage::ReadAsync(Concurrency::cancellation_token canc
 
 When the bytes are ready to be sent, we write asynchronously to the **OutputStream** of the **SerialDevice** object using the **DataWriter** object.
 
-``` C#
+```csharp
 private async void sendTextButton_Click(object sender, RoutedEventArgs e)
 {	
     // ...
@@ -389,7 +389,7 @@ private async Task WriteAsync()
 
 You can cancel the read operation by using **CancellationToken** on the Task. Initialize the **CancellationToken** object and pass that as an argument to the read task.
 
-``` C#
+```csharp
 
 private async void comPortInput_Click(object sender, RoutedEventArgs e)
 {
@@ -440,7 +440,7 @@ When closing the connection with the device, we cancel all pending I/O operation
 
 In this sample, we proceed to also refresh the list of devices connected.
 
-``` C#
+```csharp
 private void closeDevice_Click(object sender, RoutedEventArgs e)
 {
     try

--- a/Samples/ShiftRegister/CS/README.md
+++ b/Samples/ShiftRegister/CS/README.md
@@ -188,7 +188,7 @@ Before we add any code to MainPage.xaml.cs, we need to add a reference to the Wi
 
  * Add the following line at the top of MainPage.xaml.cs
 
-``` C#
+```csharp
 using Windows.Devices.Gpio;
 ```
 
@@ -196,7 +196,7 @@ With the references added, let's start adding code. The complete code we impleme
 
 Variables and Constants
 
-``` C#
+```csharp
 // use these constants for controlling how the initial time interval for clocking in serial data to the shift register.
 private const double TIMER_INTERVAL = 100; // value is milliseconds and denotes the timer interval
 private const double TIME_DELAY = 1;
@@ -247,7 +247,7 @@ The method `InitializeSystem()`
 
  * Sets up the timer used control the frequency at which the RPi2 or RPi3 sends one bit of data to the shift register
 
-``` C#
+```csharp
 private void InitializeSystem()
 {
     // initialize the GPIO pins we will use for bit-banging our serial data to the shift register
@@ -314,7 +314,7 @@ The method `SendDataBit()`
  in the shift register. The toggling of the serial clock pin by the RPi2 or RPi3 to clock in the data bit also causes the previous eight bits of data in the shift register to shift one bit position with the bit in the last position being lost.
  After clocking in the data bit, all bits in `pinMask` are left shifted one bit position. The value of `pinMask` is then checked and, depending on whether the LED lighting pattern is set as inverted, the least significant bit (LSB) of 'pinMask' is set to either a '1' or '0'.
 
-``` C#
+```csharp
 private void SendDataBit()
 {
     if ((pinMask & 0x80) > 0)
@@ -356,7 +356,7 @@ private void SendDataBit()
 `ToggleButtonClicked()` is triggered when the app user clicks on the button on the display screen to invert the LEDs. This method inverts all the bits in `pinMask`, sets or clears the flag `areLedsInverted` depending on what the previous state was.
  Finally, it changes the color of the button - red when the LEDs are inverted and gray when they are not.
 
-``` C#
+```csharp
 private void ToggleButtonClicked(object sender, RoutedEventArgs e)
 {
     pinMask ^= 0xFF;
@@ -389,7 +389,7 @@ Congratulations! You've successfully connected an 8-bit serial-in, parallel-out 
 
 ### The complete MainPage.xaml.cs code
 
-``` C#
+```csharp
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Samples/ShiftRegister/README.md
+++ b/Samples/ShiftRegister/README.md
@@ -198,7 +198,7 @@ Before we add any code to MainPage.xaml.cs, we need to add a reference to the Wi
 
  * Add the following line at the top of MainPage.xaml.cs
 
-``` C#
+```csharp
 using Windows.Devices.Gpio;
 ```
 
@@ -206,7 +206,7 @@ With the references added, let's start adding code. The complete code we impleme
 
 Variables and Constants
 
-``` C#
+```csharp
 // use these constants for controlling how the initial time interval for clocking in serial data to the shift register.
 private const double TIMER_INTERVAL = 100; // value is milliseconds and denotes the timer interval
 private const double TIME_DELAY = 1;
@@ -257,7 +257,7 @@ The method `InitializeSystem()`
 
  * Sets up the timer used control the frequency at which the RPi2 or RPi3 sends one bit of data to the shift register
 
-``` C#
+```csharp
 private void InitializeSystem()
 {
     // initialize the GPIO pins we will use for bit-banging our serial data to the shift register
@@ -324,7 +324,7 @@ The method `SendDataBit()`
  in the shift register. The toggling of the serial clock pin by the RPi2 or RPi3 to clock in the data bit also causes the previous eight bits of data in the shift register to shift one bit position with the bit in the last position being lost.
  After clocking in the data bit, all bits in `pinMask` are left shifted one bit position. The value of `pinMask` is then checked and, depending on whether the LED lighting pattern is set as inverted, the least significant bit (LSB) of 'pinMask' is set to either a '1' or '0'.
 
-``` C#
+```csharp
 private void SendDataBit()
 {
     if ((pinMask & 0x80) > 0)
@@ -366,7 +366,7 @@ private void SendDataBit()
 `ToggleButtonClicked()` is triggered when the app user clicks on the button on the display screen to invert the LEDs. This method inverts all the bits in `pinMask`, sets or clears the flag `areLedsInverted` depending on what the previous state was.
  Finally, it changes the color of the button - red when the LEDs are inverted and gray when they are not.
 
-``` C#
+```csharp
 private void ToggleButtonClicked(object sender, RoutedEventArgs e)
 {
     pinMask ^= 0xFF;
@@ -399,7 +399,7 @@ Congratulations! You've successfully connected an 8-bit serial-in, parallel-out 
 
 ### The complete MainPage.xaml.cs code
 
-``` C#
+```csharp
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Samples/TempForceSensor/CS/README.md
+++ b/Samples/TempForceSensor/CS/README.md
@@ -80,7 +80,7 @@ we read the sensor data through ADC, and the value will be displayed on the scre
 
 * Timer Code
 Setup timer in C#:
-``` C#
+```csharp
 public MainPage()
 {
 	// ...
@@ -99,7 +99,7 @@ private void Timer_Tick(object sender, object e)
 ```
 
 * Initialize SPI pin
-``` C#
+```csharp
 private async void InitSPI()
 {
     try
@@ -123,7 +123,7 @@ private async void InitSPI()
 
 * read the sensor data through SPI communication
 
-``` C#
+```csharp
 
 /*Raspberry Pi 2 or 3  Parameters*/
 private const string SPI_CONTROLLER_NAME = "SPI0";  /* For Raspberry Pi 2 or 3, use SPI0                             */
@@ -155,7 +155,7 @@ public void DisplayTextBoxContents()
 
 * Convert sensor bit data to a number
 
-``` C#
+```csharp
 /* This is the conversion for MCP3208 which is a 12 bits output; Uncomment this if you are using MCP3208 */
 // public int convertToInt(byte[] data)
 // {

--- a/Samples/TempForceSensor/README.md
+++ b/Samples/TempForceSensor/README.md
@@ -90,7 +90,7 @@ we read the sensor data through ADC, and the value will be displayed on the scre
 
 * Timer Code
 Setup timer in C#:
-``` C#
+```csharp
 public MainPage()
 {
 	// ...
@@ -109,7 +109,7 @@ private void Timer_Tick(object sender, object e)
 ```
 
 * Initialize SPI pin
-``` C#
+```csharp
 private async void InitSPI()
 {
     try
@@ -133,7 +133,7 @@ private async void InitSPI()
 
 * read the sensor data through SPI communication
 
-``` C#
+```csharp
 
 /*Raspberry Pi 2 or 3  Parameters*/
 private const string SPI_CONTROLLER_NAME = "SPI0";  /* For Raspberry Pi 2 or 3, use SPI0                             */
@@ -165,7 +165,7 @@ public void DisplayTextBoxContents()
 
 * Convert sensor bit data to a number
 
-``` C#
+```csharp
 /* This is the conversion for MCP3208 which is a 12 bits output; Uncomment this if you are using MCP3208 */
 // public int convertToInt(byte[] data)
 // {

--- a/Samples/ValveControl/CS/README.md
+++ b/Samples/ValveControl/CS/README.md
@@ -76,7 +76,7 @@ the flow of liquid through the valve.
 
 Here is how you set up the application to use the Flow object in C#:
 
-``` C#
+```csharp
 public MainPage()
 {
     this.InitializeComponent();

--- a/Samples/ValveControl/README.md
+++ b/Samples/ValveControl/README.md
@@ -86,7 +86,7 @@ the flow of liquid through the valve.
 
 Here is how you set up the application to use the Flow object in C#:
 
-``` C#
+```csharp
 public MainPage()
 {
     this.InitializeComponent();

--- a/Samples/VideoCaptureSample/CS/README.md
+++ b/Samples/VideoCaptureSample/CS/README.md
@@ -73,7 +73,7 @@ When the MainPage is being initialized, sample enumerates all available Video Ca
 Then it initalizes **MediaCapture** object that can be configured to capture video and/or audio only. In the sample, we use AudioAndVideo capture mode.
 
 
-``` C#
+```csharp
 private async void EnumerateCameras()
 {
     var devices = await Windows.Devices.Enumeration.DeviceInformation.FindAllAsync(Windows.Devices.Enumeration.DeviceClass.VideoCapture);
@@ -123,7 +123,7 @@ private async void InitMediaCapture()
 
 Once MediaCapture object has been initialized, clicking on `Start Capturing` begins media capture to a file in Videos Library folder for DefaultAccount. Sample also enables preview that is wired to a **CaptureElement** XAML element.
 
-``` C#
+```csharp
 private async Task StartMediaCaptureSession()
 {
     await StopMediaCaptureSession();
@@ -141,7 +141,7 @@ private async Task StartMediaCaptureSession()
 
 To end capturing and preview, clicking on the `End Capture` button stops preview and stops recording to a file. It may take a few seconds to flush all data to the video file before it can be played back.
 
-``` C#
+```csharp
 private async Task StopMediaCaptureSession()
 {
     if (isRecording)
@@ -157,7 +157,7 @@ private async Task StopMediaCaptureSession()
 
 After a file has been recorded, it can be played back by pressing `Play Captured VIdeo` button. This sets up a stream from the file to **MediaElement** XAML control.
 
-``` C#
+```csharp
 private async void playVideo(object sender, RoutedEventArgs e)
 {
     Windows.Storage.StorageFile storageFile = await Windows.Storage.KnownFolders.VideosLibrary.GetFileAsync(fileName);

--- a/Samples/VideoCaptureSample/README.md
+++ b/Samples/VideoCaptureSample/README.md
@@ -83,7 +83,7 @@ When the MainPage is being initialized, sample enumerates all available Video Ca
 Then it initalizes **MediaCapture** object that can be configured to capture video and/or audio only. In the sample, we use AudioAndVideo capture mode.
 
 
-``` C#
+```csharp
 private async void EnumerateCameras()
 {
     var devices = await Windows.Devices.Enumeration.DeviceInformation.FindAllAsync(Windows.Devices.Enumeration.DeviceClass.VideoCapture);
@@ -133,7 +133,7 @@ private async void InitMediaCapture()
 
 Once MediaCapture object has been initialized, clicking on `Start Capturing` begins media capture to a file in Videos Library folder for DefaultAccount. Sample also enables preview that is wired to a **CaptureElement** XAML element.
 
-``` C#
+```csharp
 private async Task StartMediaCaptureSession()
 {
     await StopMediaCaptureSession();
@@ -151,7 +151,7 @@ private async Task StartMediaCaptureSession()
 
 To end capturing and preview, clicking on the `End Capture` button stops preview and stops recording to a file. It may take a few seconds to flush all data to the video file before it can be played back.
 
-``` C#
+```csharp
 private async Task StopMediaCaptureSession()
 {
     if (isRecording)
@@ -167,7 +167,7 @@ private async Task StopMediaCaptureSession()
 
 After a file has been recorded, it can be played back by pressing `Play Captured VIdeo` button. This sets up a stream from the file to **MediaElement** XAML control.
 
-``` C#
+```csharp
 private async void playVideo(object sender, RoutedEventArgs e)
 {
     Windows.Storage.StorageFile storageFile = await Windows.Storage.KnownFolders.VideosLibrary.GetFileAsync(fileName);

--- a/Samples/WebcamApp/CS/README.md
+++ b/Samples/WebcamApp/CS/README.md
@@ -78,7 +78,7 @@ For accessing the web cam, the microphone, and the default storage folders, you 
 * **initVideo_Click** initializes the device for both audio and video when `Initialize Audio and Video` is clicked.   
 * **initAudioOnly_Click** initializes the device for audio only when `Initialize Audio Only` is clicked.  
  
-``` C#  
+```csharp  
 private async void initVideo_Click(object sender, RoutedEventArgs e)  
 { 
    // ...  
@@ -123,7 +123,7 @@ When the camera is initialized successfully, we start the preview in **initVideo
   
 When the `Take Photo` button is clicked, we capture the image, store it in the default storage, and display it in the XAML canvas element in **takePhoto_Click**  
   
-``` C#  
+```csharp  
 private async void initVideo_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  
@@ -172,7 +172,7 @@ The code below shows how we accomplish this. Once the recording is stopped, we s
   
 **NOTE:** In order to hear the audio, an audio device (ex: earphones) must be connected to the analog audio output on Raspberry Pi2. On MinnowBoard Max, audio output is available via HDMI  
   
-``` C#  
+```csharp  
 private async void recordVideo_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  
@@ -226,7 +226,7 @@ The code below shows how we accomplish this. Once the recording is stopped, we s
   
 **NOTE:** In order to hear the audio, an audio device (ex: earphones) must be connected to the analog audio output on Raspberry Pi2. On MinnowBoard Max, audio output is available via HDMI  
   
-``` C#  
+```csharp  
 private async void recordAudio_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  
@@ -269,7 +269,7 @@ There are two callbacks illustrated in the sample: **MediaCapture.Failed** and *
   
 We assign these in the **initVideo_Click** and **initAudio_Click** functions  
   
-``` C#  
+```csharp  
 private async void initVideo_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  

--- a/Samples/WebcamApp/README.md
+++ b/Samples/WebcamApp/README.md
@@ -88,7 +88,7 @@ For accessing the web cam, the microphone, and the default storage folders, you 
 * **initVideo_Click** initializes the device for both audio and video when `Initialize Audio and Video` is clicked.   
 * **initAudioOnly_Click** initializes the device for audio only when `Initialize Audio Only` is clicked.  
  
-``` C#  
+```csharp  
 private async void initVideo_Click(object sender, RoutedEventArgs e)  
 { 
    // ...  
@@ -133,7 +133,7 @@ When the camera is initialized successfully, we start the preview in **initVideo
   
 When the `Take Photo` button is clicked, we capture the image, store it in the default storage, and display it in the XAML canvas element in **takePhoto_Click**  
   
-``` C#  
+```csharp  
 private async void initVideo_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  
@@ -182,7 +182,7 @@ The code below shows how we accomplish this. Once the recording is stopped, we s
   
 **NOTE:** In order to hear the audio, an audio device (ex: earphones) must be connected to the analog audio output on Raspberry Pi2. On MinnowBoard Max, audio output is available via HDMI  
   
-``` C#  
+```csharp  
 private async void recordVideo_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  
@@ -236,7 +236,7 @@ The code below shows how we accomplish this. Once the recording is stopped, we s
   
 **NOTE:** In order to hear the audio, an audio device (ex: earphones) must be connected to the analog audio output on Raspberry Pi2. On MinnowBoard Max, audio output is available via HDMI  
   
-``` C#  
+```csharp  
 private async void recordAudio_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  
@@ -279,7 +279,7 @@ There are two callbacks illustrated in the sample: **MediaCapture.Failed** and *
   
 We assign these in the **initVideo_Click** and **initAudio_Click** functions  
   
-``` C#  
+```csharp  
 private async void initVideo_Click(object sender, RoutedEventArgs e)  
 {  
     // ...  

--- a/Samples/WiFiConnector/CS/README.md
+++ b/Samples/WiFiConnector/CS/README.md
@@ -92,7 +92,7 @@ The first step to access the device is to request access using the static `WiFiA
 
 When access is granted, any of the WiFiAdapter methods can now be used. So, we start by trying to find a WiFi adapter on the current device, using the WiFiAdapter device selector.
 
-``` C#
+```csharp
 
     var access = await WiFiAdapter.RequestAccessAsync();
     if (access != WiFiAccessStatus.Allowed)
@@ -121,7 +121,7 @@ When access is granted, any of the WiFiAdapter methods can now be used. So, we s
 
 Alternatively, `WiFiAdapter.FindAllAdaptersAsync()` can be used to find all WiFi adapters to achieve the same.
 
-``` C#
+```csharp
 // Not part of the sample:
 var result = await WiFiAdapter.FindAllAdaptersAsync();
 if (result.Count >= 1)
@@ -136,7 +136,7 @@ if (result.Count >= 1)
 
 The next step is to scan for available WiFi networks, this can be achieved using the `WiFiAdapter.ScanAsync()` method.
 
-``` C#
+```csharp
 private async void Button_Click(object sender, RoutedEventArgs e)
 {
     try
@@ -154,7 +154,7 @@ private async void Button_Click(object sender, RoutedEventArgs e)
 
 When the scan is complete, the `WiFiAdapter.NetworkReport` property is updated which  can then be used to get and display information to identify each of the WiFi networks found using a read-only collection of `WiFiAvailableNetwork`s. We add each to the result collection, so it can then be mapped to Xaml UI using properties of the `WiFiNetworkDisplay` helper class.
 
-``` C#
+```csharp
 
     private async Task DisplayNetworkReportAsync(WiFiNetworkReport report)
     {
@@ -187,7 +187,7 @@ When the scan is complete, the `WiFiAdapter.NetworkReport` property is updated w
 
 When a WiFi network is selected from the ones displayed, we need to determine if we want to collect the password credential. The WiFi network authentication type is what we need to determine that:
 
-``` C#
+```csharp
     
     private void UpdateNetworkKeyVisibility()
     {
@@ -207,7 +207,7 @@ When a WiFi network is selected from the ones displayed, we need to determine if
 
 To determine if the network supports WPS we can check if the current network supports **WiFiWpsKind.PushButton**.
 
-``` C#
+```csharp
 
     public async Task<bool> IsWpsPushButtonAvailableAsync()
     {
@@ -221,7 +221,7 @@ To determine if the network supports WPS we can check if the current network sup
 
 And finally, to determine if EAP network support is available we can check to see if the authentication type is **Rsna** or **Wpa**.
 
-``` C#
+```csharp
 
     public bool IsEapAvailable
     {
@@ -237,7 +237,7 @@ Finally, to connect to the selected network, an overload of `WiFiAdapter.Connect
 
 The status returned in the async result indicates whether the connection was successful or. Only `WiFiConnectionStatus.Success` indicates success. Other returned values indicates the connection failure reason.
 
-``` C#
+```csharp
     
     Task<WiFiConnectionResult> didConnect = null;
     WiFiConnectionResult result = null;
@@ -317,7 +317,7 @@ The status returned in the async result indicates whether the connection was suc
 
 If you need to disconnect, `WiFiAdapter.Disconnect()` can be used.
 
-``` C#
+```csharp
 
     private void Disconnect_Click(object sender, RoutedEventArgs e)
     {

--- a/Samples/WiFiConnector/README.md
+++ b/Samples/WiFiConnector/README.md
@@ -102,7 +102,7 @@ The first step to access the device is to request access using the static `WiFiA
 
 When access is granted, any of the WiFiAdapter methods can now be used. So, we start by trying to find a WiFi adapter on the current device, using the WiFiAdapter device selector.
 
-``` C#
+```csharp
 
     var access = await WiFiAdapter.RequestAccessAsync();
     if (access != WiFiAccessStatus.Allowed)
@@ -131,7 +131,7 @@ When access is granted, any of the WiFiAdapter methods can now be used. So, we s
 
 Alternatively, `WiFiAdapter.FindAllAdaptersAsync()` can be used to find all WiFi adapters to achieve the same.
 
-``` C#
+```csharp
 // Not part of the sample:
 var result = await WiFiAdapter.FindAllAdaptersAsync();
 if (result.Count >= 1)
@@ -146,7 +146,7 @@ if (result.Count >= 1)
 
 The next step is to scan for available WiFi networks, this can be achieved using the `WiFiAdapter.ScanAsync()` method.
 
-``` C#
+```csharp
 private async void Button_Click(object sender, RoutedEventArgs e)
 {
     try
@@ -164,7 +164,7 @@ private async void Button_Click(object sender, RoutedEventArgs e)
 
 When the scan is complete, the `WiFiAdapter.NetworkReport` property is updated which  can then be used to get and display information to identify each of the WiFi networks found using a read-only collection of `WiFiAvailableNetwork`s. We add each to the result collection, so it can then be mapped to Xaml UI using properties of the `WiFiNetworkDisplay` helper class.
 
-``` C#
+```csharp
 
     private async Task DisplayNetworkReportAsync(WiFiNetworkReport report)
     {
@@ -197,7 +197,7 @@ When the scan is complete, the `WiFiAdapter.NetworkReport` property is updated w
 
 When a WiFi network is selected from the ones displayed, we need to determine if we want to collect the password credential. The WiFi network authentication type is what we need to determine that:
 
-``` C#
+```csharp
     
     private void UpdateNetworkKeyVisibility()
     {
@@ -217,7 +217,7 @@ When a WiFi network is selected from the ones displayed, we need to determine if
 
 To determine if the network supports WPS we can check if the current network supports **WiFiWpsKind.PushButton**.
 
-``` C#
+```csharp
 
     public async Task<bool> IsWpsPushButtonAvailableAsync()
     {
@@ -231,7 +231,7 @@ To determine if the network supports WPS we can check if the current network sup
 
 And finally, to determine if EAP network support is available we can check to see if the authentication type is **Rsna** or **Wpa**.
 
-``` C#
+```csharp
 
     public bool IsEapAvailable
     {
@@ -247,7 +247,7 @@ Finally, to connect to the selected network, an overload of `WiFiAdapter.Connect
 
 The status returned in the async result indicates whether the connection was successful or. Only `WiFiConnectionStatus.Success` indicates success. Other returned values indicates the connection failure reason.
 
-``` C#
+```csharp
     
     Task<WiFiConnectionResult> didConnect = null;
     WiFiConnectionResult result = null;
@@ -327,7 +327,7 @@ The status returned in the async result indicates whether the connection was suc
 
 If you need to disconnect, `WiFiAdapter.Disconnect()` can be used.
 
-``` C#
+```csharp
 
     private void Disconnect_Click(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
This process was made by find and replace with `Regex` as search mode.

![image](https://user-images.githubusercontent.com/31348972/63503495-e0c82c00-c4cf-11e9-9985-753ba62c0185.png)

This edit was made in one file before in https://github.com/microsoft/Windows-iotcore-samples/pull/402

And now the code for that samples appears well in the live docs.
Screenshot before the fix is in https://github.com/microsoft/Windows-iotcore-samples/pull/402
Screenshot after the fix:
![image](https://user-images.githubusercontent.com/31348972/63503653-2edd2f80-c4d0-11e9-8cce-08e06173c7ac.png)

This PR fixes the same issue but for ALL C# codes in this repo.