### PR TITLE
Build IoTMediaPlayer for ARM64 iMX8M

### DIFF
--- a/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer.sln
+++ b/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer.sln
@@ -8,9 +8,11 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
@@ -18,6 +20,9 @@ Global
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|ARM.ActiveCfg = Debug|ARM
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|ARM.Build.0 = Debug|ARM
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|ARM.Deploy.0 = Debug|ARM
+		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|ARM64.Build.0 = Debug|ARM64
+		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|x64.ActiveCfg = Debug|x64
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|x64.Build.0 = Debug|x64
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Debug|x64.Deploy.0 = Debug|x64
@@ -27,6 +32,9 @@ Global
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|ARM.ActiveCfg = Release|ARM
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|ARM.Build.0 = Release|ARM
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|ARM.Deploy.0 = Release|ARM
+		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|ARM64.ActiveCfg = Release|ARM64
+		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|ARM64.Build.0 = Release|ARM64
+		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|ARM64.Deploy.0 = Release|ARM64
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|x64.ActiveCfg = Release|x64
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|x64.Build.0 = Release|x64
 		{7D3768F5-8A8F-48A6-8556-5C31DE20504C}.Release|x64.Deploy.0 = Release|x64

--- a/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/IoTCoreMediaPlayer.csproj
+++ b/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/IoTCoreMediaPlayer.csproj
@@ -12,12 +12,12 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageCertificateKeyFile>IoTCoreMediaPlayer_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <RuntimeIdentifiers>win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot;win10-arm64;win10-arm64-aot</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -125,11 +125,37 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <OutputPath>bin\ARM64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/MainPage.xaml.cs
+++ b/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/MainPage.xaml.cs
@@ -40,6 +40,7 @@ namespace IoTCoreMediaPlayer
             ".pya",
 
             // video
+            ".mkv",
             ".wm",
             ".m4v",
             ".wmv",

--- a/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/Package.appxmanifest
+++ b/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:iot="http://schemas.microsoft.com/appx/manifest/iot/windows10" IgnorableNamespaces="uap mp iot">
   <Identity Name="IoTCoreMediaPlayer" Publisher="CN=MSFT" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="ff6e5894-2e0f-46fa-98d1-cc08912bd732" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -69,5 +69,6 @@
     <uap:Capability Name="musicLibrary" />
     <uap:Capability Name="videosLibrary" />
     <uap:Capability Name="removableStorage" />
+    <iot:Capability Name="lowLevelDevices" />
   </Capabilities>
 </Package>

--- a/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/Package.appxmanifest
+++ b/Samples/IoTCoreMediaPlayer/CS/IoTCoreMediaPlayer/Package.appxmanifest
@@ -69,6 +69,7 @@
     <uap:Capability Name="musicLibrary" />
     <uap:Capability Name="videosLibrary" />
     <uap:Capability Name="removableStorage" />
+    <!-- Add lowLevelDevices capability for iMX8M VPU decoder support -->
     <iot:Capability Name="lowLevelDevices" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
 - Change target to 16299 for ARM64 support
 - Update nuget dependencies
 - Add ARM64 build target
 - Add .MKV as known media file type
 - Add LowLevelDevice capability to application manifest to
   enable talking to iMX8M VPU codec.